### PR TITLE
playoff: Don't waste a bunch of whitespace at the top of the RC brackets page

### DIFF
--- a/scoring/web/playoff/remoteControlBrackets.jsp
+++ b/scoring/web/playoff/remoteControlBrackets.jsp
@@ -244,22 +244,9 @@ SPAN.TIE {
     id="dummy"
     style="position: absolute">
     <br />
-
     <c:forEach
       items="${allBracketInfo}"
       var="bracketInfo">
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
 
       <div class='center'>Head to Head Round
         ${bracketInfo.firstRound}, Head to Head Bracket
@@ -267,6 +254,13 @@ SPAN.TIE {
       <br />
                         
    ${bracketInfo.topRightBracketOutput}
+     <c:if test="${allBracketInfo.size() > 1}">
+       <br />
+       <br />
+       <hr />
+       <br />
+       <br />
+     </c:if>
 </c:forEach>
 
     <span id="bottom">&nbsp;</span>


### PR DESCRIPTION
Here's what the separation between multiple brackets on the same page looks like, by the way.

<img width="1308" alt="screen shot 2017-01-29 at 2 15 45 pm" src="https://cloud.githubusercontent.com/assets/735098/22407582/c8a4923a-e62e-11e6-9814-fee86ae79c19.png">
