### PR TITLE
Correct the omission of the bracketIdx when doing an AJAX bracket query

### DIFF
--- a/scoring/src/fll/util/JsonUtilities.java
+++ b/scoring/src/fll/util/JsonUtilities.java
@@ -91,6 +91,7 @@ public final class JsonUtilities {
    */
   public static List<BracketLeafResultSet> generateJsonBracketInfo(final String division,
                                                                    final Map<Integer, Integer> ids,
+                                                                   final int bracketIdx,
                                                                    final Connection connection,
                                                                    final PerformanceScoreCategory perf,
                                                                    final BracketData bracketData,
@@ -122,17 +123,17 @@ public final class JsonUtilities {
                                                 runNumber);
         // Sane request checks
         if (noShow) {
-          datalist.add(new BracketLeafResultSet(tbc, -2.0, row
+          datalist.add(new BracketLeafResultSet(tbc, -2.0, bracketIdx + "-" + row
               + "-" + playoffRound));
         } else if (!realScore
             || !showOnlyVerifiedScores || Queries.isVerified(connection, currentTournament, teamNumber, runNumber)) {
           if ((playoffRound == numPlayoffRounds
               && !showFinalsScores)
               || !realScore) {
-            datalist.add(new BracketLeafResultSet(tbc, -1.0, row
+            datalist.add(new BracketLeafResultSet(tbc, -1.0, bracketIdx + "-" + row
                 + "-" + playoffRound));
           } else {
-            datalist.add(new BracketLeafResultSet(tbc, computedTeamScore, row
+            datalist.add(new BracketLeafResultSet(tbc, computedTeamScore, bracketIdx + "-" + row
                 + "-" + playoffRound));
           }
         }

--- a/scoring/src/fll/web/ajax/AJAXBracketQueryServlet.java
+++ b/scoring/src/fll/web/ajax/AJAXBracketQueryServlet.java
@@ -198,7 +198,7 @@ public class AJAXBracketQueryServlet extends BaseFLLServlet {
   }
 
   /**
-   * @see JsonUtilities#generateJsonBracketInfo(String, Map, Connection,
+   * @see JsonUtilities#generateJsonBracketInfo(String, Map, int, Connection,
    *      fll.xml.PerformanceScoreCategory, BracketData, boolean, boolean)
    * @throws SQLException
    */
@@ -222,7 +222,7 @@ public class AJAXBracketQueryServlet extends BaseFLLServlet {
     final BracketData bd = new BracketData(connection, bracketInfo.getBracket(), playoffRoundNumber, playoffRoundNumber
         + roundsLong - 1, rowsPerTeam, showFinalsScores, showOnlyVerifiedScores, bracketInfo.getIndex());
 
-    return JsonUtilities.generateJsonBracketInfo(bracketInfo.getBracket(), pairedMap, connection,
+    return JsonUtilities.generateJsonBracketInfo(bracketInfo.getBracket(), pairedMap, bracketInfo.getIndex(), connection,
                                                  description.getPerformance(), bd, showOnlyVerifiedScores,
                                                  showFinalsScores);
   }


### PR DESCRIPTION
By the way it's been a while since I've touched `fll-sw` and don't remember what your style conventions are, so please excuse if I left a line too long or something.