### PR TITLE
Head to head dynamic update bug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,5 @@
+* #606 - Fix bug where the wrong team is sent to the head to head display in a dynamic update 
+
 Release 12.1.0
 ==============
 

--- a/scoring/src/fll/web/playoff/Playoff.java
+++ b/scoring/src/fll/web/playoff/Playoff.java
@@ -676,9 +676,7 @@ public final class Playoff {
                                        final int tournament,
                                        final String playoffDivision)
       throws SQLException {
-    LOGGER.info("HERE...");
     final int maxPerformanceRound = getMaxPerformanceRound(connection, tournament, playoffDivision);
-    LOGGER.info("Max performance round: " + maxPerformanceRound);
     if (maxPerformanceRound < 0) {
       return -1;
     } else {

--- a/scoring/src/fll/web/playoff/ScoresheetGenerator.java
+++ b/scoring/src/fll/web/playoff/ScoresheetGenerator.java
@@ -265,8 +265,8 @@ public class ScoresheetGenerator {
               final int dbLine = Queries.getPlayoffTableLineNumber(connection, tournament, teamB.getTeamNumber(),
                                                                    performanceRunB);
               final int maxPlayoffRound = Playoff.getMaxPlayoffRound(connection, tournament, division);
-              H2HUpdateWebSocket.updateBracket(division, dbLine, playoffRound, maxPlayoffRound, teamA.getTeamNumber(),
-                                               teamA.getTeamName(), null, ScoreType.INTEGER, // doesn't
+              H2HUpdateWebSocket.updateBracket(division, dbLine, playoffRound, maxPlayoffRound, teamB.getTeamNumber(),
+                                               teamB.getTeamName(), null, ScoreType.INTEGER, // doesn't
                                                                                              // matter
                                                false, true, m_table[j]);
             }


### PR DESCRIPTION
This was found at the Eagan tournament on 11/11/2017. The head to head display was sometimes putting the team in the wrong row and sometimes not updating the display. I know that this fixes the team being in the wrong row. I could not reproduce the display not updating, but wondering if this bug also caused it.