### PR TITLE
Allow one to delete head to head brackets

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,4 @@
+* #1071 - prevent the user from uninitializing a playoff bracket that will cause problems with run numbers
 * #1069 - support viewing a bye run
 * sort teams by table during head to head
 * Don't import awards script data when importing performance data

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,4 @@
+* #1071 - allow the user to delete a playoff bracket
 * #1071 - prevent the user from uninitializing a playoff bracket that will cause problems with run numbers
 * #1069 - support viewing a bye run
 * sort teams by table during head to head

--- a/src/integrationTest/java/fll/web/FullTournamentTest.java
+++ b/src/integrationTest/java/fll/web/FullTournamentTest.java
@@ -985,9 +985,23 @@ public class FullTournamentTest {
             // need to get the score entry form
             IntegrationTestUtils.loadPage(selenium, seleniumWait, selectTeamPage);
 
-            new Select(selenium.findElement(By.id("select-verify-teamnumber"))).selectByValue(teamNumber
-                + "-"
-                + runNumber);
+            // search for the element by team number due to the run numbers changing in head
+            // to head
+            final Select verifySelect = new Select(selenium.findElement(By.id("select-verify-teamnumber")));
+            boolean found = false;
+            for (final WebElement option : verifySelect.getOptions()) {
+              final String value = option.getAttribute("value");
+              if (value.startsWith(teamNumber
+                  + "-")) {
+                verifySelect.selectByValue(value);
+                found = true;
+                break;
+              }
+            }
+            if (!found) {
+              fail("Unable to find verification for team "
+                  + teamNumber);
+            }
 
             // submit the page
             selenium.findElement(By.id("verify_submit")).click();

--- a/src/main/java/fll/db/Queries.java
+++ b/src/main/java/fll/db/Queries.java
@@ -275,6 +275,33 @@ public final class Queries {
   }
 
   /**
+   * Figure out the highest run number across all teams in the specified
+   * tournament. Does not ignore unverified scores.
+   * 
+   * @param connection database connection
+   * @param tournament the tournament to check
+   * @return the highest run number that the team has completed
+   * @throws SQLException on a database error
+   */
+  public static int getMaxRunNumber(final Connection connection,
+                                    final Tournament tournament)
+      throws SQLException {
+    try (
+        PreparedStatement prep = connection.prepareStatement("SELECT MAX(RunNumber) FROM Performance WHERE Tournament = ?")) {
+      prep.setInt(1, tournament.getTournamentID());
+      try (ResultSet rs = prep.executeQuery()) {
+        final int runNumber;
+        if (rs.next()) {
+          runNumber = rs.getInt(1);
+        } else {
+          runNumber = 0;
+        }
+        return runNumber;
+      }
+    }
+  }
+
+  /**
    * Insert a performance score into the database and do all appropriate updates
    * to the playoff tables and notifications to the UI code.
    *

--- a/src/main/java/fll/web/playoff/DeletePlayoff.java
+++ b/src/main/java/fll/web/playoff/DeletePlayoff.java
@@ -97,10 +97,10 @@ public class DeletePlayoff extends BaseFLLServlet {
           UninitializePlayoff.uninitializePlayoffBracket(connection, tournamentID, bracketName, minRun, maxRun);
 
           try (
-              PreparedStatement deleteAutoFinish = connection.prepareStatement("DELETE FROM playoff_bracket_teams WHERE tournament_id = ? AND bracket_name = ?")) {
-            deleteAutoFinish.setInt(1, tournamentID);
-            deleteAutoFinish.setString(2, bracketName);
-            deleteAutoFinish.executeUpdate();
+              PreparedStatement delete = connection.prepareStatement("DELETE FROM playoff_bracket_teams WHERE tournament_id = ? AND bracket_name = ?")) {
+            delete.setInt(1, tournamentID);
+            delete.setString(2, bracketName);
+            delete.executeUpdate();
           }
 
           connection.commit();

--- a/src/main/java/fll/web/playoff/DeletePlayoff.java
+++ b/src/main/java/fll/web/playoff/DeletePlayoff.java
@@ -31,10 +31,10 @@ import fll.web.UserRole;
 import fll.web.WebUtils;
 
 /**
- * Uninitialize a playoff division.
+ * Delete a playoff bracket.
  */
-@WebServlet("/playoff/UninitializePlayoff")
-public class UninitializePlayoff extends BaseFLLServlet {
+@WebServlet("/playoff/DeletePlayoff")
+public class DeletePlayoff extends BaseFLLServlet {
 
   private static final org.apache.logging.log4j.Logger LOGGER = org.apache.logging.log4j.LogManager.getLogger();
 
@@ -59,9 +59,9 @@ public class UninitializePlayoff extends BaseFLLServlet {
 
         final int tournamentID = Queries.getCurrentTournament(connection);
 
-        final String division = request.getParameter("division");
-        if (null == division
-            || "".equals(division)) {
+        final String bracketName = request.getParameter("division");
+        if (null == bracketName
+            || "".equals(bracketName)) {
           SessionAttributes.appendToMessage(session,
                                             "<p class='error'>No playoff bracket specified to uninitialize</p>");
           WebUtils.sendRedirect(application, response, "/playoff/index.jsp");
@@ -75,7 +75,7 @@ public class UninitializePlayoff extends BaseFLLServlet {
                 + " WHERE tournament = ?" //
                 + " AND event_division = ?")) {
           getMinMaxRunPrep.setInt(1, tournamentID);
-          getMinMaxRunPrep.setString(2, division);
+          getMinMaxRunPrep.setString(2, bracketName);
           try (ResultSet getMinMaxRunResult = getMinMaxRunPrep.executeQuery()) {
             if (getMinMaxRunResult.next()) {
               minRun = getMinMaxRunResult.getInt(1);
@@ -87,24 +87,33 @@ public class UninitializePlayoff extends BaseFLLServlet {
           }
         }
 
+        final boolean initialized = Queries.isPlayoffDataInitialized(connection, tournamentID, bracketName);
         final int playoffMaxPerformanceRound = Playoff.getMaxPerformanceRound(connection, tournamentID);
         final int maxPerformanceRound = Queries.getMaxRunNumber(connection, tournamentID);
-        if (maxRun == playoffMaxPerformanceRound
-            && maxPerformanceRound <= maxRun) {
+        if (!initialized
+            || (maxRun == playoffMaxPerformanceRound
+                && maxPerformanceRound <= maxRun)) {
 
-          uninitializePlayoffBracket(connection, tournamentID, division, minRun, maxRun);
+          UninitializePlayoff.uninitializePlayoffBracket(connection, tournamentID, bracketName, minRun, maxRun);
+
+          try (
+              PreparedStatement deleteAutoFinish = connection.prepareStatement("DELETE FROM playoff_bracket_teams WHERE tournament_id = ? AND bracket_name = ?")) {
+            deleteAutoFinish.setInt(1, tournamentID);
+            deleteAutoFinish.setString(2, bracketName);
+            deleteAutoFinish.executeUpdate();
+          }
 
           connection.commit();
 
-          LOGGER.info("Uninitialized playoff division "
-              + division);
+          LOGGER.info("Deleted playoff bracket "
+              + bracketName);
 
-          SessionAttributes.appendToMessage(session, "<p id='success'>Uninitialized playoff bracket "
-              + division
+          SessionAttributes.appendToMessage(session, "<p id='success'>Deleted playoff bracket "
+              + bracketName
               + ".</p>");
         } else {
-          SessionAttributes.appendToMessage(session, "<p class='error'>Unable to uninitialize playoff bracket "
-              + division
+          SessionAttributes.appendToMessage(session, "<p class='error'>Unable to delete playoff bracket "
+              + bracketName
               + ".</p>");
         }
 
@@ -116,64 +125,6 @@ public class UninitializePlayoff extends BaseFLLServlet {
     } catch (final SQLException e) {
       LOGGER.error(e.getMessage(), e);
       throw new FLLRuntimeException("Database error uninitializing playoffs", e);
-    }
-  }
-
-  /**
-   * Do the work of uninitializing a playoff bracket. Handles the case where the
-   * playoff bracket isn't initialized. Should be called within a transaction. The
-   * caller needs to check that it's safe to uninialize this bracket.
-   * 
-   * @param connection database connection
-   * @param tournamentID tournament
-   * @param division playoff bracket
-   * @param minRun min run for the bracket
-   * @param maxRun max run for the bracket
-   * @throws SQLException on a database error
-   */
-  /* package */ static void uninitializePlayoffBracket(final Connection connection,
-                                                       final int tournamentID,
-                                                       final String division,
-                                                       final int minRun,
-                                                       final int maxRun)
-      throws SQLException {
-    if (minRun != -1
-        && maxRun != -1) {
-      try (PreparedStatement deletePerformance = connection.prepareStatement("DELETE FROM Performance" //
-          + " WHERE runNumber >= ?"//
-          + " AND runNumber <= ?" //
-          + " AND tournament = ?" //
-          + " AND teamnumber IN (" //
-          + "  SELECT DISTINCT team" //
-          + "    FROM PlayoffData" //
-          + "    WHERE event_division = ? )")) {
-        deletePerformance.setInt(1, minRun);
-        deletePerformance.setInt(2, maxRun);
-        deletePerformance.setInt(3, tournamentID);
-        deletePerformance.setString(4, division);
-        deletePerformance.executeUpdate();
-      }
-    }
-
-    try (
-        PreparedStatement deletePlayoff = connection.prepareStatement("DELETE FROM PlayoffTableData WHERE event_division = ? AND tournament = ?")) {
-      deletePlayoff.setString(1, division);
-      deletePlayoff.setInt(2, tournamentID);
-      deletePlayoff.executeUpdate();
-    }
-
-    try (
-        PreparedStatement deletePlayoff = connection.prepareStatement("DELETE FROM PlayoffData WHERE event_division = ? AND tournament = ?")) {
-      deletePlayoff.setString(1, division);
-      deletePlayoff.setInt(2, tournamentID);
-      deletePlayoff.executeUpdate();
-    }
-
-    try (
-        PreparedStatement deleteAutoFinish = connection.prepareStatement("DELETE FROM automatic_finished_playoff WHERE tournament_id = ? and bracket_name = ?")) {
-      deleteAutoFinish.setInt(1, tournamentID);
-      deleteAutoFinish.setString(2, division);
-      deleteAutoFinish.executeUpdate();
     }
   }
 }

--- a/src/main/java/fll/web/playoff/Playoff.java
+++ b/src/main/java/fll/web/playoff/Playoff.java
@@ -450,7 +450,9 @@ public final class Playoff {
 
     final List<Integer> teamNumbers = new LinkedList<>();
     for (final Team t : firstRound) {
-      teamNumbers.add(t.getTeamNumber());
+      if (!Team.isInternalTeamNumber(t.getTeamNumber())) {
+        teamNumbers.add(t.getTeamNumber());
+      }
     }
     final String errors = Playoff.involvedInUnfinishedPlayoff(connection, currentTournament, teamNumbers);
     if (null != errors) {

--- a/src/main/java/fll/web/playoff/Playoff.java
+++ b/src/main/java/fll/web/playoff/Playoff.java
@@ -744,6 +744,33 @@ public final class Playoff {
   }
 
   /**
+   * Get max performance run number across all playoff brackets.
+   *
+   * @return performance round, -1 if there are no playoff rounds
+   * @param connection database connection
+   * @param currentTournament tournament to work with
+   * @throws SQLException on database error
+   */
+  public static int getMaxPerformanceRound(final Connection connection,
+                                           final int currentTournament)
+      throws SQLException {
+    try (PreparedStatement maxPrep = connection.prepareStatement("SELECT MAX(run_number) FROM PlayoffData WHERE" //
+        + " tournament = ?")) {
+
+      maxPrep.setInt(1, currentTournament);
+
+      try (ResultSet max = maxPrep.executeQuery()) {
+        if (max.next()) {
+          final int runNumber = max.getInt(1);
+          return runNumber;
+        } else {
+          return -1;
+        }
+      }
+    }
+  }
+
+  /**
    * Compute the assignments to the initial playoff brackets.
    *
    * @param numTeams will be rounded up to the next power of 2
@@ -1968,4 +1995,5 @@ public final class Playoff {
       }
     }
   }
+
 }

--- a/src/main/java/fll/web/playoff/PlayoffSessionData.java
+++ b/src/main/java/fll/web/playoff/PlayoffSessionData.java
@@ -211,7 +211,7 @@ public final class PlayoffSessionData implements Serializable {
   /**
    * @return brackets that can be uninitialized
    */
-  public Collection<String> getSaveToUninitialize() {
+  public Collection<String> getSafeToUninitialize() {
     return Collections.unmodifiableCollection(safeToUninitialize);
   }
 

--- a/src/main/java/fll/web/playoff/PlayoffSessionData.java
+++ b/src/main/java/fll/web/playoff/PlayoffSessionData.java
@@ -47,16 +47,31 @@ public final class PlayoffSessionData implements Serializable {
     mInitializedBrackets = new LinkedList<>();
     mUninitializedBrackets = new LinkedList<>();
     safeToUninitialize = new LinkedList<>();
+    safeToDelete = new LinkedList<>();
     for (final String bracketName : mExistingBrackets) {
       final int bracketMaxRounds = Playoff.getMaxPerformanceRound(connection, mCurrentTournament.getTournamentID(),
                                                                   bracketName);
 
-      if (Queries.isPlayoffDataInitialized(connection, mCurrentTournament.getTournamentID(), bracketName)) {
+      final boolean bracketInitialized = Queries.isPlayoffDataInitialized(connection,
+                                                                          mCurrentTournament.getTournamentID(),
+                                                                          bracketName);
+      if (!bracketInitialized
+          || (bracketMaxRounds == playoffMaxPerformanceRound
+              && maxPerformanceRound <= bracketMaxRounds)) {
+        // It's safe to delete the last bracket initialized or a bracket that hasn't
+        // been initialized. Otherwise we
+        // leave gaps in the performance round numbers. We also check against the max
+        // performance round in case there are performance rounds after the playoffs.
+        // This shouldn't happen, but we should check anyway.
+        safeToDelete.add(bracketName);
+      }
+
+      if (bracketInitialized) {
         mInitializedBrackets.add(bracketName);
 
         if (bracketMaxRounds == playoffMaxPerformanceRound
             && maxPerformanceRound <= bracketMaxRounds) {
-          // It's only safe to uninitialize the last bracket initialized, otherwise we
+          // It's only safe to uninitialize the last bracket initialized. Otherwise we
           // leave gaps in the performance round numbers. We also check against the max
           // performance round in case there are performance rounds after the playoffs.
           // This shouldn't happen, but we should check anyway.
@@ -214,6 +229,15 @@ public final class PlayoffSessionData implements Serializable {
    */
   public Collection<String> getSafeToUninitialize() {
     return Collections.unmodifiableCollection(safeToUninitialize);
+  }
+
+  private final Collection<String> safeToDelete;
+
+  /**
+   * @return brackets that can be deleted.
+   */
+  public Collection<String> getSafeToDelete() {
+    return Collections.unmodifiableCollection(safeToDelete);
   }
 
 }

--- a/src/main/java/fll/web/playoff/PlayoffSessionData.java
+++ b/src/main/java/fll/web/playoff/PlayoffSessionData.java
@@ -50,17 +50,18 @@ public final class PlayoffSessionData implements Serializable {
     for (final String bracketName : mExistingBrackets) {
       final int bracketMaxRounds = Playoff.getMaxPerformanceRound(connection, mCurrentTournament.getTournamentID(),
                                                                   bracketName);
-      if (bracketMaxRounds == playoffMaxPerformanceRound
-          && maxPerformanceRound <= bracketMaxRounds) {
-        // It's only safe to uninitialize the last bracket initialized, otherwise we
-        // leave gaps in the performance round numbers. We also check against the max
-        // performance round in case there are performance rounds after the playoffs.
-        // This shouldn't happen, but we should check anyway.
-        safeToUninitialize.add(bracketName);
-      }
 
       if (Queries.isPlayoffDataInitialized(connection, mCurrentTournament.getTournamentID(), bracketName)) {
         mInitializedBrackets.add(bracketName);
+
+        if (bracketMaxRounds == playoffMaxPerformanceRound
+            && maxPerformanceRound <= bracketMaxRounds) {
+          // It's only safe to uninitialize the last bracket initialized, otherwise we
+          // leave gaps in the performance round numbers. We also check against the max
+          // performance round in case there are performance rounds after the playoffs.
+          // This shouldn't happen, but we should check anyway.
+          safeToUninitialize.add(bracketName);
+        }
       } else {
         mUninitializedBrackets.add(bracketName);
       }

--- a/src/main/java/fll/web/playoff/UninitializePlayoff.java
+++ b/src/main/java/fll/web/playoff/UninitializePlayoff.java
@@ -143,14 +143,10 @@ public class UninitializePlayoff extends BaseFLLServlet {
           + " WHERE runNumber >= ?"//
           + " AND runNumber <= ?" //
           + " AND tournament = ?" //
-          + " AND teamnumber IN (" //
-          + "  SELECT DISTINCT team" //
-          + "    FROM PlayoffData" //
-          + "    WHERE event_division = ? )")) {
+      )) {
         deletePerformance.setInt(1, minRun);
         deletePerformance.setInt(2, maxRun);
         deletePerformance.setInt(3, tournamentID);
-        deletePerformance.setString(4, division);
         deletePerformance.executeUpdate();
       }
     }

--- a/src/main/web/playoff/index.jsp
+++ b/src/main/web/playoff/index.jsp
@@ -358,7 +358,7 @@ fll.web.playoff.PlayoffIndex.populateContext(application, session, pageContext);
                         <select id='uninitialize-division'
                             name='division'>
                             <c:forEach
-                                items="${playoff_data.initializedBrackets }"
+                                items="${playoff_data.safeToUninitialize }"
                                 var="division">
                                 <option value='${division}'>${division}</option>
                             </c:forEach>
@@ -366,7 +366,7 @@ fll.web.playoff.PlayoffIndex.populateContext(application, session, pageContext);
                         <input type='submit'
                             id='uninitialize_playoff-submit'
                             value='Submit'
-                            onclick='return confirm("Are you absolutly sure you want to delete all scores associated with this head to head bracket?")' />
+                            onclick='return confirm("Are you absolutely sure you want to delete all scores associated with this head to head bracket?")' />
 
                         <a
                             href='javascript:display("UninitializeBracketsHelp")'>[help]</a>

--- a/src/main/web/playoff/index.jsp
+++ b/src/main/web/playoff/index.jsp
@@ -376,9 +376,10 @@ fll.web.playoff.PlayoffIndex.populateContext(application, session, pageContext);
                             head bracket. In most cases this link should
                             not be used. It may be useful if a head to
                             head bracket was initialized by mistake and
-                            a different one should be run first. Any
-                            scores that have been entered for this
-                            bracket will be deleted.<a
+                            a different one should be run first or the
+                            options for how the bracket is initialized
+                            should change. Any scores that have been
+                            entered for this bracket will be deleted.<a
                                 href='javascript:hide("UninitializeBracketsHelp")'>[hide]</a>
                         </div>
 

--- a/src/main/web/playoff/index.jsp
+++ b/src/main/web/playoff/index.jsp
@@ -384,7 +384,40 @@ fll.web.playoff.PlayoffIndex.populateContext(application, session, pageContext);
                         </div>
 
                     </form>
-                    <%-- end uninitialize division --%>
+                    <%-- end uninitialize bracket --%>
+                </li>
+
+                <li>
+                    <%-- delete bracket --%>
+                    <form name="delete_playoff" method="POST"
+                        action="DeletePlayoff">
+                        Select bracket to delete:
+                        <select id='delete-division' name='division'>
+                            <c:forEach
+                                items="${playoff_data.safeToDelete }"
+                                var="division">
+                                <option value='${division}'>${division}</option>
+                            </c:forEach>
+                        </select>
+                        <input type='submit' id='delete_playoff-submit'
+                            value='Submit'
+                            onclick='return confirm("Are you absolutely sure you want to delete all scores associated with this head to head bracket?")' />
+
+                        <a
+                            href='javascript:display("DeleteBracketsHelp")'>[help]</a>
+                        <div id='DeleteBracketsHelp' class='help'
+                            style='display: none'>
+                            This link is used to delete a head to head
+                            bracket. In most cases this link should not
+                            be used. It may be useful if a head to head
+                            bracket was created by mistake. Any scores
+                            that have been entered for this bracket will
+                            be deleted.<a
+                                href='javascript:hide("DeleteBracketsHelp")'>[hide]</a>
+                        </div>
+
+                    </form>
+                    <%-- end delete bracket --%>
                 </li>
 
                 <li>


### PR DESCRIPTION
We have the ability to uninitialize a bracket. To clear things out it would be good to be able to delete a bracket. This will only allow deleting the last bracket due to how scores are entered in performance.