### PR TITLE
Issue with Chromebooks loading the subjective application

### DIFF
--- a/src/main/java/fll/web/InitFilter.java
+++ b/src/main/java/fll/web/InitFilter.java
@@ -99,6 +99,7 @@ public class InitFilter implements Filter {
       httpResponse.setHeader("Cache-Control", "no-store"); // HTTP 1.1
       httpResponse.setHeader("Pragma", "no-cache"); // HTTP 1.0
       httpResponse.setDateHeader("Expires", 0); // proxy server cache
+      httpResponse.setHeader("Access-Control-Allow-Origin", "*");
 
       requestToPass = httpRequest;
     } else {


### PR DESCRIPTION
Everything works fine on the demo site. However at the tournament the site won't load on some devices. I'm seeing a message suggesting that the javascript to check if the server is online is timing out. What's really odd is if we take a Chromebook that is having a problem and connect it to the demo site the demo site works; then we point it at the local tournament site and it starts working.