### PR TITLE
Error generating team performance report

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,4 @@
+* #1057 - Remove duplicate copy of performance goals in team performance report
 * #1074 - Make ReplayTournament more robust for handling other databases, particularly head to head
 
 Release 17.4.0

--- a/src/main/java/fll/web/report/PerformanceScoreReport.java
+++ b/src/main/java/fll/web/report/PerformanceScoreReport.java
@@ -261,12 +261,6 @@ public class PerformanceScoreReport extends BaseFLLServlet {
       }
     }
 
-    for (final AbstractGoal goal : performance.getAllGoals()) {
-
-      outputGoal(document, tableBody, performance, scores, goal);
-
-    } // foreach goal
-
     // totals
     final Element totalRow = FOPUtils.createTableRow(document);
     tableBody.appendChild(totalRow);


### PR DESCRIPTION
I'm seeing duplicate goal rows for a team when visiting "/report/PerformanceScoreReport". This is when looking at the sample-32 database. In particular team 405.
[performanceScoreReport.pdf](https://github.com/jpschewe/fll-sw/files/10713774/performanceScoreReport.pdf)
