### PR TITLE
Allow import of tournament level information

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,4 @@
+* #906 - Handle differences in the awards script fields when merging a database
 * #1077 - Increase font size on finalist teams display
 * #1083 - Make it clear which report to use for finalist check in
 * #1080 - Add blank lines after paragraphs in the awards script

--- a/src/main/documentation/workflows/import_database.dot
+++ b/src/main/documentation/workflows/import_database.dot
@@ -40,4 +40,6 @@ CommitTeamChanges -> CheckTeamInfo;
 
 ExecuteImport -> CheckTournamentExists [label="Found differences"];
 
+ExecuteImport -> "finished";
+
 }

--- a/src/main/documentation/workflows/import_database.dot
+++ b/src/main/documentation/workflows/import_database.dot
@@ -38,6 +38,6 @@ CheckTeamInfo -> "resolveTeamInfoDifferences.jsp" [label="Found differences"];
 
 CommitTeamChanges -> CheckTeamInfo;
 
-ExecuteImport -> CheckTeamInfo [label="Found differences"];
+ExecuteImport -> CheckTournamentExists [label="Found differences"];
 
 }

--- a/src/main/documentation/workflows/import_database.dot
+++ b/src/main/documentation/workflows/import_database.dot
@@ -28,7 +28,7 @@ FindMissingTeams -> "promptCreateMissingTeams.jsp" [label="Found missing teams"]
 
 AddMissingTeams -> CheckTeamInfo;
 
-CheckTeamInfo -> ExecuteImport;
+CheckTeamInfo -> CheckAwardsScriptInfo;
 
 CheckTeamInfo -> "resolveTeamInfoDifferences.jsp" [label="Found differences"];
 
@@ -37,6 +37,14 @@ CheckTeamInfo -> "resolveTeamInfoDifferences.jsp" [label="Found differences"];
 "resolveTeamInfoDifferences.jsp" -> "selectTournament.jsp" [label="Cancel"];
 
 CommitTeamChanges -> CheckTeamInfo;
+
+CheckAwardsScriptInfo -> "resolveAwardsScriptDifferences.jsp" [label="Found differences"];
+
+CheckAwardsScriptInfo -> ExecuteImport;
+
+"resolveAwardsScriptDifferences.jsp" -> CommitAwardsScriptChanges;
+
+CommitAwardsScriptChanges -> CheckAwardsScriptInfo;
 
 ExecuteImport -> CheckTournamentExists [label="Found differences"];
 

--- a/src/main/java/fll/db/ImportDB.java
+++ b/src/main/java/fll/db/ImportDB.java
@@ -2529,7 +2529,7 @@ public final class ImportDB {
   }
 
   /**
-   * Check for differences between two tournaments in team information.
+   * Check for differences in a tournament between two databases.
    *
    * @param sourceConnection the incoming database
    * @param destConnection the database to insert the data into

--- a/src/main/java/fll/db/ImportDB.java
+++ b/src/main/java/fll/db/ImportDB.java
@@ -62,6 +62,8 @@ import fll.util.FLLRuntimeException;
 import fll.web.GatherBugReport;
 import fll.web.UserRole;
 import fll.web.developer.importdb.ImportDBDump;
+import fll.web.developer.importdb.awardsScript.AwardsScriptDifference;
+import fll.web.developer.importdb.awardsScript.SponsorsDifference;
 import fll.xml.AbstractGoal;
 import fll.xml.ChallengeDescription;
 import fll.xml.ChallengeParser;
@@ -2629,6 +2631,49 @@ public final class ImportDB {
         }
       } // source result set
     }
+    return differences;
+  }
+
+  /**
+   * Check the awards script information between the two databases.
+   * 
+   * @param sourceConnection source database
+   * @param destConnection destination database
+   * @param tournament tournament to compare
+   * @return list of differences, empty if no differences
+   * @throws SQLException on a database error
+   */
+  public static List<AwardsScriptDifference> checkAwardsScriptInfo(final Connection sourceConnection,
+                                                                   final Connection destConnection,
+                                                                   final String tournament)
+      throws SQLException {
+    final List<AwardsScriptDifference> differences = new LinkedList<>();
+
+    final Tournament sourceTournament = Tournament.findTournamentByName(sourceConnection, tournament);
+    final Tournament destTournament = Tournament.findTournamentByName(destConnection, tournament);
+
+    // presenter - non-numeric category
+    // presenter - subjective category
+    // macros
+    // award order
+
+    // category text - non-numeric category
+    // category text - subjective category
+
+    // num performance awards
+
+    // section
+    // SectionDifference
+
+    // sponsors
+    if (!AwardsScript.isSponsorsSpecifiedForTournament(sourceConnection, sourceTournament)) {
+      final List<String> sourceValue = AwardsScript.getSponsors(sourceConnection, sourceTournament);
+      final List<String> destValue = AwardsScript.getSponsors(destConnection, destTournament);
+      if (!sourceValue.equals(destValue)) {
+        differences.add(new SponsorsDifference(sourceValue, destValue));
+      }
+    }
+
     return differences;
   }
 

--- a/src/main/java/fll/db/ImportDB.java
+++ b/src/main/java/fll/db/ImportDB.java
@@ -56,14 +56,25 @@ import fll.TournamentLevel;
 import fll.TournamentLevel.NoSuchTournamentLevelException;
 import fll.TournamentTeam;
 import fll.Utilities;
+import fll.db.AwardsScript.Macro;
+import fll.db.AwardsScript.Section;
 import fll.db.TeamPropertyDifference.TeamProperty;
 import fll.util.FLLInternalException;
 import fll.util.FLLRuntimeException;
 import fll.web.GatherBugReport;
 import fll.web.UserRole;
 import fll.web.developer.importdb.ImportDBDump;
+import fll.web.developer.importdb.awardsScript.AwardOrderDifference;
 import fll.web.developer.importdb.awardsScript.AwardsScriptDifference;
+import fll.web.developer.importdb.awardsScript.MacroValueDifference;
+import fll.web.developer.importdb.awardsScript.NonNumericCategoryPresenterDifference;
+import fll.web.developer.importdb.awardsScript.NonNumericCategoryTextDifference;
+import fll.web.developer.importdb.awardsScript.NumPerformanceAwardsDifference;
+import fll.web.developer.importdb.awardsScript.SectionTextDifference;
 import fll.web.developer.importdb.awardsScript.SponsorsDifference;
+import fll.web.developer.importdb.awardsScript.SubjectiveCategoryPresenterDifference;
+import fll.web.developer.importdb.awardsScript.SubjectiveCategoryTextDifference;
+import fll.web.report.awards.AwardCategory;
 import fll.xml.AbstractGoal;
 import fll.xml.ChallengeDescription;
 import fll.xml.ChallengeParser;
@@ -2637,13 +2648,15 @@ public final class ImportDB {
   /**
    * Check the awards script information between the two databases.
    * 
+   * @param description challenge description for the tournament
    * @param sourceConnection source database
    * @param destConnection destination database
    * @param tournament tournament to compare
    * @return list of differences, empty if no differences
    * @throws SQLException on a database error
    */
-  public static List<AwardsScriptDifference> checkAwardsScriptInfo(final Connection sourceConnection,
+  public static List<AwardsScriptDifference> checkAwardsScriptInfo(final ChallengeDescription description,
+                                                                   final Connection sourceConnection,
                                                                    final Connection destConnection,
                                                                    final String tournament)
       throws SQLException {
@@ -2652,18 +2665,86 @@ public final class ImportDB {
     final Tournament sourceTournament = Tournament.findTournamentByName(sourceConnection, tournament);
     final Tournament destTournament = Tournament.findTournamentByName(destConnection, tournament);
 
-    // presenter - non-numeric category
-    // presenter - subjective category
-    // macros
-    // award order
+    // macro values
+    for (final Macro macro : Macro.values()) {
+      if (!AwardsScript.isMacroSpecifiedForTournament(sourceConnection, sourceTournament, macro)) {
+        final String sourceValue = AwardsScript.getMacroValue(sourceConnection, sourceTournament, macro);
+        final String destValue = AwardsScript.getMacroValue(destConnection, destTournament, macro);
+        if (!sourceValue.equals(destValue)) {
+          differences.add(new MacroValueDifference(macro, sourceValue, destValue));
+        }
+      }
+    }
 
-    // category text - non-numeric category
-    // category text - subjective category
+    // award order
+    if (!AwardsScript.isAwardOrderSpecifiedForTournament(sourceConnection, sourceTournament)) {
+      final List<AwardCategory> sourceValue = AwardsScript.getAwardOrder(description, sourceConnection,
+                                                                         sourceTournament);
+      final List<AwardCategory> destValue = AwardsScript.getAwardOrder(description, destConnection, destTournament);
+      if (!sourceValue.equals(destValue)) {
+        differences.add(new AwardOrderDifference(sourceValue, destValue));
+      }
+    }
+
+    for (final NonNumericCategory category : description.getNonNumericCategories()) {
+      // presenter - non-numeric category
+      if (!AwardsScript.isPresenterSpecifiedForTournament(sourceConnection, sourceTournament, category)) {
+        final String sourceValue = AwardsScript.getPresenter(sourceConnection, sourceTournament, category);
+        final String destValue = AwardsScript.getPresenter(destConnection, destTournament, category);
+        if (!sourceValue.equals(destValue)) {
+          differences.add(new NonNumericCategoryPresenterDifference(category, sourceValue, destValue));
+        }
+      }
+
+      // category text - non-numeric category
+      if (!AwardsScript.isCategoryTextSpecifiedForTournament(sourceConnection, sourceTournament, category)) {
+        final String sourceValue = AwardsScript.getCategoryText(sourceConnection, sourceTournament, category);
+        final String destValue = AwardsScript.getCategoryText(destConnection, destTournament, category);
+        if (!sourceValue.equals(destValue)) {
+          differences.add(new NonNumericCategoryTextDifference(category, sourceValue, destValue));
+        }
+      }
+    }
+
+    for (final SubjectiveScoreCategory category : description.getSubjectiveCategories()) {
+      // presenter - subjective category
+      if (!AwardsScript.isPresenterSpecifiedForTournament(sourceConnection, sourceTournament, category)) {
+        final String sourceValue = AwardsScript.getPresenter(sourceConnection, sourceTournament, category);
+        final String destValue = AwardsScript.getPresenter(destConnection, destTournament, category);
+        if (!sourceValue.equals(destValue)) {
+          differences.add(new SubjectiveCategoryPresenterDifference(category, sourceValue, destValue));
+        }
+      }
+
+      // category text - subjective category
+      if (!AwardsScript.isCategoryTextSpecifiedForTournament(sourceConnection, sourceTournament, category)) {
+        final String sourceValue = AwardsScript.getCategoryText(sourceConnection, sourceTournament, category);
+        final String destValue = AwardsScript.getCategoryText(destConnection, destTournament, category);
+        if (!sourceValue.equals(destValue)) {
+          differences.add(new SubjectiveCategoryTextDifference(category, sourceValue, destValue));
+        }
+      }
+    }
 
     // num performance awards
+    if (!AwardsScript.isNumPerformanceAwardsSpecifiedForTournament(sourceConnection, sourceTournament)) {
+      final int sourceValue = AwardsScript.getNumPerformanceAwards(sourceConnection, sourceTournament);
+      final int destValue = AwardsScript.getNumPerformanceAwards(destConnection, destTournament);
+      if (sourceValue != destValue) {
+        differences.add(new NumPerformanceAwardsDifference(sourceValue, destValue));
+      }
+    }
 
-    // section
-    // SectionDifference
+    // section text
+    for (final Section section : Section.values()) {
+      if (!AwardsScript.isSectionSpecifiedForTournament(sourceConnection, sourceTournament, section)) {
+        final String sourceValue = AwardsScript.getSectionText(sourceConnection, sourceTournament, section);
+        final String destValue = AwardsScript.getSectionText(destConnection, destTournament, section);
+        if (!sourceValue.equals(destValue)) {
+          differences.add(new SectionTextDifference(section, sourceValue, destValue));
+        }
+      }
+    }
 
     // sponsors
     if (!AwardsScript.isSponsorsSpecifiedForTournament(sourceConnection, sourceTournament)) {

--- a/src/main/java/fll/db/TeamPropertyDifference.java
+++ b/src/main/java/fll/db/TeamPropertyDifference.java
@@ -11,7 +11,7 @@ import java.io.Serializable;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Represents a different in a property for a team.
+ * Represents a difference in a property for a team.
  */
 public class TeamPropertyDifference implements Serializable {
   /**

--- a/src/main/java/fll/web/developer/importdb/ExecuteImport.java
+++ b/src/main/java/fll/web/developer/importdb/ExecuteImport.java
@@ -75,7 +75,7 @@ public class ExecuteImport extends BaseFLLServlet {
       final boolean differences = ImportDB.checkForDifferences(sourceConnection, destConnection, tournament);
       if (differences) {
         message.append("<p class='error'>Error, there are still differences that need to be resolved before the import can be completed.</p>");
-        session.setAttribute(SessionAttributes.REDIRECT_URL, "CheckTeamInfo");
+        session.setAttribute(SessionAttributes.REDIRECT_URL, "CheckTournamentExists");
       } else {
         DumpDB.automaticBackup(destConnection, "before-import");
 

--- a/src/main/java/fll/web/developer/importdb/ImportDbSessionInfo.java
+++ b/src/main/java/fll/web/developer/importdb/ImportDbSessionInfo.java
@@ -117,7 +117,7 @@ public final class ImportDbSessionInfo {
   }
 
   /**
-   * @return see {@link #setAwardsScriptDifferences(Collection)}
+   * @return see {@link #setAwardsScriptDifferences(List)}
    */
   public List<AwardsScriptDifference> getAwardsScriptDifferences() {
     return Collections.unmodifiableList(awardsScriptDifferences);

--- a/src/main/java/fll/web/developer/importdb/ImportDbSessionInfo.java
+++ b/src/main/java/fll/web/developer/importdb/ImportDbSessionInfo.java
@@ -11,7 +11,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-import jakarta.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -19,6 +18,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import fll.Team;
 import fll.db.TeamPropertyDifference;
+import fll.web.developer.importdb.awardsScript.AwardsScriptDifference;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Information needed for importing a database. This object is stored in the
@@ -89,7 +90,7 @@ public final class ImportDbSessionInfo {
   private final List<TeamPropertyDifference> teamDifferences = new LinkedList<>();
 
   /**
-   * @param v the differences between the source and destination database
+   * @param v the team differences between the source and destination database
    */
   public void setTeamDifferences(final List<TeamPropertyDifference> v) {
     teamDifferences.clear();
@@ -102,6 +103,24 @@ public final class ImportDbSessionInfo {
    */
   public List<TeamPropertyDifference> getTeamDifferences() {
     return Collections.unmodifiableList(teamDifferences);
+  }
+
+  private final List<AwardsScriptDifference> awardsScriptDifferences = new LinkedList<>();
+
+  /**
+   * @param v the awards script differences between the source and destination
+   *          database
+   */
+  public void setAwardsScriptDifferences(final List<AwardsScriptDifference> v) {
+    awardsScriptDifferences.clear();
+    awardsScriptDifferences.addAll(v);
+  }
+
+  /**
+   * @return see {@link #setAwardsScriptDifferences(Collection)}
+   */
+  public List<AwardsScriptDifference> getAwardsScriptDifferences() {
+    return Collections.unmodifiableList(awardsScriptDifferences);
   }
 
   private boolean importPerformance = true;

--- a/src/main/java/fll/web/developer/importdb/awardsScript/AwardOrderDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/AwardOrderDifference.java
@@ -15,18 +15,19 @@ import java.util.List;
 import fll.Tournament;
 import fll.db.AwardsScript;
 import fll.util.FLLInternalException;
+import fll.web.report.awards.AwardCategory;
 
 /**
- * Difference in the sponsors list between 2 databases.
+ * Difference in the award order between 2 databases.
  */
-public final class SponsorsDifference extends AwardsScriptDifference {
+public final class AwardOrderDifference extends AwardsScriptDifference {
 
   /**
    * @param sourceValue see {@link #getSourceValue()}
-   * @param destValue see {@link #getDestValues()}
+   * @param destValue see {@link #getDestValue()}
    */
-  public SponsorsDifference(final List<String> sourceValue,
-                            final List<String> destValue) {
+  public AwardOrderDifference(final List<AwardCategory> sourceValue,
+                              final List<AwardCategory> destValue) {
     this.sourceValue = Collections.unmodifiableList(new ArrayList<>(sourceValue));
     this.destValue = Collections.unmodifiableList(new ArrayList<>(destValue));
   }
@@ -34,39 +35,39 @@ public final class SponsorsDifference extends AwardsScriptDifference {
   @Override
   public String getDescription() {
     final StringBuilder description = new StringBuilder();
-    description.append("<div>The list of sponsors is different between the source database and the destination database.</div>");
+    description.append("<div>The order of awards is different between the source database and the destination database.</div>");
     description.append("<div>Source:<ul>");
-    for (final String svalue : sourceValue) {
+    for (final AwardCategory svalue : sourceValue) {
       description.append("<li>");
-      description.append(svalue);
+      description.append(svalue.getTitle());
       description.append("</li>");
     }
     description.append("</ul></div>");
     description.append("<div>Destination:<ul>");
-    for (final String dvalue : destValue) {
+    for (final AwardCategory dvalue : destValue) {
       description.append("<li>");
-      description.append(dvalue);
+      description.append(dvalue.getTitle());
       description.append("</li>");
     }
     description.append("</ul></div>");
     return description.toString();
   }
 
-  private final List<String> sourceValue;
+  private final List<AwardCategory> sourceValue;
 
   /**
-   * @return sponsors in the source database (unmodifiable)
+   * @return award in the source database (unmodifiable)
    */
-  public List<String> getSourceValue() {
+  public List<AwardCategory> getSourceValue() {
     return sourceValue;
   }
 
-  private final List<String> destValue;
+  private final List<AwardCategory> destValue;
 
   /**
-   * @return sponsors in the destination database (unmodifiable)
+   * @return award in the destination database (unmodifiable)
    */
-  public List<String> getDestValue() {
+  public List<AwardCategory> getDestValue() {
     return destValue;
   }
 
@@ -79,21 +80,20 @@ public final class SponsorsDifference extends AwardsScriptDifference {
       throws SQLException {
     switch (action) {
     case KEEP_DESTINATION:
-      AwardsScript.updateSponsorsForTournament(sourceConnection, sourceTournament, getDestValue());
+      AwardsScript.updateAwardOrderForTournament(sourceConnection, sourceTournament, getDestValue());
       break;
     case KEEP_SOURCE_AS_TOURNAMENT:
-      AwardsScript.updateSponsorsForTournament(destConnection, destTournament, getSourceValue());
+      AwardsScript.updateAwardOrderForTournament(destConnection, destTournament, getSourceValue());
       break;
     case KEEP_SOURCE_AS_TOURNAMENT_LEVEL:
-      AwardsScript.updateSponsorsForTournamentLevel(destConnection, destTournament.getLevel(), getSourceValue());
+      AwardsScript.updateAwardOrderForTournamentLevel(destConnection, destTournament.getLevel(), getSourceValue());
       break;
     case KEEP_SOURCE_AS_SEASON:
-      AwardsScript.updateSponsorsForSeason(destConnection, getSourceValue());
+      AwardsScript.updateAwardOrderForSeason(destConnection, getSourceValue());
       break;
     default:
       throw new FLLInternalException(String.format("Unknown enum value for %s: %s", action.getClass().getName(),
                                                    action.getName()));
     }
-
   }
 }

--- a/src/main/java/fll/web/developer/importdb/awardsScript/AwardsScriptDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/AwardsScriptDifference.java
@@ -6,13 +6,36 @@
 
 package fll.web.developer.importdb.awardsScript;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import fll.Tournament;
+
 /**
  * Base class for differences in the awards script between two databases.
  */
 public abstract class AwardsScriptDifference {
 
   /**
-   * @return human readable description of the difference.
+   * @return human readable description of the difference. This value can contain
+   *         HTML tags.
    */
   public abstract String getDescription();
+
+  /**
+   * Resolve the difference using the specified action.
+   * 
+   * @param sourceConnection source database
+   * @param sourceTournament source tournament
+   * @param destConnection destination database
+   * @param destTournament destination tournament
+   * @param action the action to take on the difference
+   * @throws SQLException on a database error
+   */
+  public abstract void resolveDifference(Connection sourceConnection,
+                                         Tournament sourceTournament,
+                                         Connection destConnection,
+                                         Tournament destTournament,
+                                         AwardsScriptDifferenceAction action)
+      throws SQLException;
 }

--- a/src/main/java/fll/web/developer/importdb/awardsScript/AwardsScriptDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/AwardsScriptDifference.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 High Tech Kids.  All rights reserved
+ * HighTechKids is on the web at: http://www.hightechkids.org
+ * This code is released under GPL; see LICENSE.txt for details.
+ */
+
+package fll.web.developer.importdb.awardsScript;
+
+/**
+ * Base class for differences in the awards script between two databases.
+ */
+public abstract class AwardsScriptDifference {
+
+  /**
+   * @return human readable description of the difference.
+   */
+  public abstract String getDescription();
+}

--- a/src/main/java/fll/web/developer/importdb/awardsScript/AwardsScriptDifferenceAction.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/AwardsScriptDifferenceAction.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 High Tech Kids.  All rights reserved
+ * HighTechKids is on the web at: http://www.hightechkids.org
+ * This code is released under GPL; see LICENSE.txt for details.
+ */
+
+package fll.web.developer.importdb.awardsScript;
+
+/**
+ * Possible actions to take on an awards script difference.
+ */
+public enum AwardsScriptDifferenceAction {
+
+  KEEP_DESTINATION("Keep the value in the destination database"), // (write to source tournament),
+  KEEP_SOURCE_AS_TOURNAMENT("Write the source value to the tournament layer in the destination database"), //
+  KEEP_SOURCE_AS_TOURNAMENT_LEVEL(
+      "Write the source value to the tournament level layer in the destination database - WILL EFFECT MULTIPLE TOURNAMENTS"), //
+  KEEP_SOURCE_AS_SEASON(
+      "Write the source value to the season layer in the destination database - WILL EFFECT MULTIPLE TOURNAMENTS"); //
+
+  private final String description;
+
+  /**
+   * @return user friendly description of the action
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Calls {@link #name()}. Added so that JSPs can reference the name as a
+   * property.
+   * 
+   * @return see {@link #name()}
+   */
+  public String getName() {
+    return name();
+  }
+
+  AwardsScriptDifferenceAction(final String description) {
+    this.description = description;
+  }
+}

--- a/src/main/java/fll/web/developer/importdb/awardsScript/CategoryPresenterDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/CategoryPresenterDifference.java
@@ -29,13 +29,8 @@ public abstract class CategoryPresenterDifference extends CategoryStringDifferen
   }
 
   @Override
-  public String getDescription() {
-    final StringBuilder description = new StringBuilder();
-    description.append(String.format("<div>The presenter for category %s is different between the source database and the destination database.</div>",
-                                     getCategory().getTitle()));
-    description.append(String.format("<div>Source: %s</div>", getSourceValue()));
-    description.append(String.format("<div>Destination:%s </div>", getDestValue()));
-    return description.toString();
+  public String getFieldDescription() {
+    return "presenter";
   }
 
   @Override

--- a/src/main/java/fll/web/developer/importdb/awardsScript/CategoryPresenterDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/CategoryPresenterDifference.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023 High Tech Kids.  All rights reserved
+ * HighTechKids is on the web at: http://www.hightechkids.org
+ * This code is released under GPL; see LICENSE.txt for details.
+ */
+
+package fll.web.developer.importdb.awardsScript;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import fll.Tournament;
+import fll.web.report.awards.AwardCategory;
+
+/**
+ * Difference in the presenter for a category between 2 databases.
+ */
+public abstract class CategoryPresenterDifference extends AwardsScriptDifference {
+
+  /**
+   * @param category see {@link #getCategory()}
+   * @param sourceValue see {@link #getSourceValue()}
+   * @param destValue see {@link #getDestValue()}
+   */
+  public CategoryPresenterDifference(final AwardCategory category,
+                                     final String sourceValue,
+                                     final String destValue) {
+    this.category = category;
+    this.sourceValue = sourceValue;
+    this.destValue = destValue;
+  }
+
+  @Override
+  public String getDescription() {
+    final StringBuilder description = new StringBuilder();
+    description.append(String.format("<div>The presenter for category %s is different between the source database and the destination database.</div>",
+                                     getCategory().getTitle()));
+    description.append(String.format("<div>Source: %s</div>", getSourceValue()));
+    description.append(String.format("<div>Destination:%s </div>", getDestValue()));
+    return description.toString();
+  }
+
+  private final AwardCategory category;
+
+  /**
+   * @return the category that has a different value
+   */
+  public AwardCategory getCategory() {
+    return category;
+  }
+
+  private final String sourceValue;
+
+  /**
+   * @return macro value in the source database
+   */
+  public final String getSourceValue() {
+    return sourceValue;
+  }
+
+  private final String destValue;
+
+  /**
+   * @return macro value in the destination database
+   */
+  public final String getDestValue() {
+    return destValue;
+  }
+
+  @Override
+  public abstract void resolveDifference(Connection sourceConnection,
+                                         Tournament sourceTournament,
+                                         Connection destConnection,
+                                         Tournament destTournament,
+                                         AwardsScriptDifferenceAction action)
+      throws SQLException;
+}

--- a/src/main/java/fll/web/developer/importdb/awardsScript/CategoryPresenterDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/CategoryPresenterDifference.java
@@ -15,7 +15,7 @@ import fll.web.report.awards.AwardCategory;
 /**
  * Difference in the presenter for a category between 2 databases.
  */
-public abstract class CategoryPresenterDifference extends AwardsScriptDifference {
+public abstract class CategoryPresenterDifference extends CategoryStringDifference {
 
   /**
    * @param category see {@link #getCategory()}
@@ -25,9 +25,7 @@ public abstract class CategoryPresenterDifference extends AwardsScriptDifference
   public CategoryPresenterDifference(final AwardCategory category,
                                      final String sourceValue,
                                      final String destValue) {
-    this.category = category;
-    this.sourceValue = sourceValue;
-    this.destValue = destValue;
+    super(category, sourceValue, destValue);
   }
 
   @Override
@@ -38,33 +36,6 @@ public abstract class CategoryPresenterDifference extends AwardsScriptDifference
     description.append(String.format("<div>Source: %s</div>", getSourceValue()));
     description.append(String.format("<div>Destination:%s </div>", getDestValue()));
     return description.toString();
-  }
-
-  private final AwardCategory category;
-
-  /**
-   * @return the category that has a different value
-   */
-  public AwardCategory getCategory() {
-    return category;
-  }
-
-  private final String sourceValue;
-
-  /**
-   * @return macro value in the source database
-   */
-  public final String getSourceValue() {
-    return sourceValue;
-  }
-
-  private final String destValue;
-
-  /**
-   * @return macro value in the destination database
-   */
-  public final String getDestValue() {
-    return destValue;
   }
 
   @Override

--- a/src/main/java/fll/web/developer/importdb/awardsScript/CategoryStringDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/CategoryStringDifference.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 High Tech Kids.  All rights reserved
+ * HighTechKids is on the web at: http://www.hightechkids.org
+ * This code is released under GPL; see LICENSE.txt for details.
+ */
+
+package fll.web.developer.importdb.awardsScript;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import fll.Tournament;
+import fll.web.report.awards.AwardCategory;
+
+/**
+ * Base class for string differences for a category
+ */
+abstract class CategoryStringDifference extends StringDifference {
+
+  /**
+   * @param sourceValue
+   * @param destValue
+   */
+  /* package */ CategoryStringDifference(final AwardCategory category,
+                                         final String sourceValue,
+                                         final String destValue) {
+    super(sourceValue, destValue);
+    this.category = category;
+  }
+
+  private final AwardCategory category;
+
+  /**
+   * @return the category that has a different value
+   */
+  public AwardCategory getCategory() {
+    return category;
+  }
+
+  @Override
+  public abstract void resolveDifference(Connection sourceConnection,
+                                         Tournament sourceTournament,
+                                         Connection destConnection,
+                                         Tournament destTournament,
+                                         AwardsScriptDifferenceAction action)
+      throws SQLException;
+}

--- a/src/main/java/fll/web/developer/importdb/awardsScript/CategoryStringDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/CategoryStringDifference.java
@@ -37,6 +37,21 @@ abstract class CategoryStringDifference extends StringDifference {
     return category;
   }
 
+  /**
+   * @return description of the field that has a difference
+   */
+  public abstract String getFieldDescription();
+
+  @Override
+  public final String getDescription() {
+    final StringBuilder description = new StringBuilder();
+    description.append(String.format("<div>The %s for category %s is different between the source database and the destination database.</div>",
+                                     getFieldDescription(), getCategory().getTitle()));
+    description.append(String.format("<div>Source: %s</div>", getSourceValue()));
+    description.append(String.format("<div>Destination:%s </div>", getDestValue()));
+    return description.toString();
+  }
+
   @Override
   public abstract void resolveDifference(Connection sourceConnection,
                                          Tournament sourceTournament,

--- a/src/main/java/fll/web/developer/importdb/awardsScript/CategoryStringDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/CategoryStringDifference.java
@@ -40,16 +40,10 @@ abstract class CategoryStringDifference extends StringDifference {
   /**
    * @return description of the field that has a difference
    */
-  public abstract String getFieldDescription();
+  protected abstract String getFieldDescription();
 
-  @Override
-  public final String getDescription() {
-    final StringBuilder description = new StringBuilder();
-    description.append(String.format("<div>The %s for category %s is different between the source database and the destination database.</div>",
-                                     getFieldDescription(), getCategory().getTitle()));
-    description.append(String.format("<div>Source: %s</div>", getSourceValue()));
-    description.append(String.format("<div>Destination:%s </div>", getDestValue()));
-    return description.toString();
+  protected final String getTextDescription() {
+    return String.format("%s for category %s", getFieldDescription(), getCategory().getTitle());
   }
 
   @Override

--- a/src/main/java/fll/web/developer/importdb/awardsScript/CategoryTextDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/CategoryTextDifference.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023 High Tech Kids.  All rights reserved
+ * HighTechKids is on the web at: http://www.hightechkids.org
+ * This code is released under GPL; see LICENSE.txt for details.
+ */
+
+package fll.web.developer.importdb.awardsScript;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import fll.Tournament;
+import fll.web.report.awards.AwardCategory;
+
+/**
+ * Difference in the text for a category between 2 databases.
+ */
+public abstract class CategoryTextDifference extends AwardsScriptDifference {
+
+  /**
+   * @param category see {@link #getCategory()}
+   * @param sourceValue see {@link #getSourceValue()}
+   * @param destValue see {@link #getDestValue()}
+   */
+  public CategoryTextDifference(final AwardCategory category,
+                                final String sourceValue,
+                                final String destValue) {
+    this.category = category;
+    this.sourceValue = sourceValue;
+    this.destValue = destValue;
+  }
+
+  @Override
+  public String getDescription() {
+    final StringBuilder description = new StringBuilder();
+    description.append(String.format("<div>The text for category %s is different between the source database and the destination database.</div>",
+                                     category.getTitle()));
+    description.append(String.format("<div>Source: %s</div>", sourceValue));
+    description.append(String.format("<div>Destination:%s </div>", destValue));
+    return description.toString();
+  }
+
+  private final AwardCategory category;
+
+  /**
+   * @return the category that has a different value
+   */
+  public AwardCategory getCategory() {
+    return category;
+  }
+
+  private final String sourceValue;
+
+  /**
+   * @return macro value in the source database
+   */
+  public String getSourceValue() {
+    return sourceValue;
+  }
+
+  private final String destValue;
+
+  /**
+   * @return macro value in the destination database
+   */
+  public String getDestValue() {
+    return destValue;
+  }
+
+  @Override
+  public abstract void resolveDifference(Connection sourceConnection,
+                                         Tournament sourceTournament,
+                                         Connection destConnection,
+                                         Tournament destTournament,
+                                         AwardsScriptDifferenceAction action)
+      throws SQLException;
+}

--- a/src/main/java/fll/web/developer/importdb/awardsScript/CategoryTextDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/CategoryTextDifference.java
@@ -29,13 +29,8 @@ public abstract class CategoryTextDifference extends CategoryStringDifference {
   }
 
   @Override
-  public String getDescription() {
-    final StringBuilder description = new StringBuilder();
-    description.append(String.format("<div>The text for category %s is different between the source database and the destination database.</div>",
-                                     getCategory().getTitle()));
-    description.append(String.format("<div>Source: %s</div>", getSourceValue()));
-    description.append(String.format("<div>Destination:%s </div>", getDestValue()));
-    return description.toString();
+  public String getFieldDescription() {
+    return "text";
   }
 
   @Override

--- a/src/main/java/fll/web/developer/importdb/awardsScript/CategoryTextDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/CategoryTextDifference.java
@@ -15,7 +15,7 @@ import fll.web.report.awards.AwardCategory;
 /**
  * Difference in the text for a category between 2 databases.
  */
-public abstract class CategoryTextDifference extends AwardsScriptDifference {
+public abstract class CategoryTextDifference extends CategoryStringDifference {
 
   /**
    * @param category see {@link #getCategory()}
@@ -25,46 +25,17 @@ public abstract class CategoryTextDifference extends AwardsScriptDifference {
   public CategoryTextDifference(final AwardCategory category,
                                 final String sourceValue,
                                 final String destValue) {
-    this.category = category;
-    this.sourceValue = sourceValue;
-    this.destValue = destValue;
+    super(category, sourceValue, destValue);
   }
 
   @Override
   public String getDescription() {
     final StringBuilder description = new StringBuilder();
     description.append(String.format("<div>The text for category %s is different between the source database and the destination database.</div>",
-                                     category.getTitle()));
-    description.append(String.format("<div>Source: %s</div>", sourceValue));
-    description.append(String.format("<div>Destination:%s </div>", destValue));
+                                     getCategory().getTitle()));
+    description.append(String.format("<div>Source: %s</div>", getSourceValue()));
+    description.append(String.format("<div>Destination:%s </div>", getDestValue()));
     return description.toString();
-  }
-
-  private final AwardCategory category;
-
-  /**
-   * @return the category that has a different value
-   */
-  public AwardCategory getCategory() {
-    return category;
-  }
-
-  private final String sourceValue;
-
-  /**
-   * @return macro value in the source database
-   */
-  public String getSourceValue() {
-    return sourceValue;
-  }
-
-  private final String destValue;
-
-  /**
-   * @return macro value in the destination database
-   */
-  public String getDestValue() {
-    return destValue;
   }
 
   @Override

--- a/src/main/java/fll/web/developer/importdb/awardsScript/CheckAwardsScriptInfo.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/CheckAwardsScriptInfo.java
@@ -69,11 +69,12 @@ public class CheckAwardsScriptInfo extends BaseFLLServlet {
 
       final List<AwardsScriptDifference> differences = ImportDB.checkAwardsScriptInfo(sourceConnection, destConnection,
                                                                                       tournament);
+      sessionInfo.setAwardsScriptDifferences(differences);
+      session.setAttribute(ImportDBDump.IMPORT_DB_SESSION_KEY, sessionInfo);
+
       if (differences.isEmpty()) {
         session.setAttribute(SessionAttributes.REDIRECT_URL, "/developer/importdb/ExecuteImport");
       } else {
-        sessionInfo.setAwardsScriptDifferences(differences);
-        session.setAttribute(ImportDBDump.IMPORT_DB_SESSION_KEY, sessionInfo);
         session.setAttribute(SessionAttributes.REDIRECT_URL,
                              "/developer/importdb/awardsScript/resolveAwardsScriptDifferences.jsp");
       }

--- a/src/main/java/fll/web/developer/importdb/awardsScript/CheckAwardsScriptInfo.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/CheckAwardsScriptInfo.java
@@ -24,6 +24,7 @@ import fll.web.UserRole;
 import fll.web.WebUtils;
 import fll.web.developer.importdb.ImportDBDump;
 import fll.web.developer.importdb.ImportDbSessionInfo;
+import fll.xml.ChallengeDescription;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
@@ -62,13 +63,14 @@ public class CheckAwardsScriptInfo extends BaseFLLServlet {
       throw new FLLInternalException("Missing tournament to import");
     }
 
+    final ChallengeDescription description = ApplicationAttributes.getChallengeDescription(application);
     final DataSource destDataSource = ApplicationAttributes.getDataSource(application);
 
     try (Connection sourceConnection = sourceDataSource.getConnection();
         Connection destConnection = destDataSource.getConnection()) {
 
-      final List<AwardsScriptDifference> differences = ImportDB.checkAwardsScriptInfo(sourceConnection, destConnection,
-                                                                                      tournament);
+      final List<AwardsScriptDifference> differences = ImportDB.checkAwardsScriptInfo(description, sourceConnection,
+                                                                                      destConnection, tournament);
       sessionInfo.setAwardsScriptDifferences(differences);
       session.setAttribute(ImportDBDump.IMPORT_DB_SESSION_KEY, sessionInfo);
 

--- a/src/main/java/fll/web/developer/importdb/awardsScript/CommitAwardsScriptChanges.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/CommitAwardsScriptChanges.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2023 High Tech Kids.  All rights reserved
+ * HighTechKids is on the web at: http://www.hightechkids.org
+ * This code is released under GPL; see LICENSE.txt for details.
+ */
+
+package fll.web.developer.importdb.awardsScript;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ListIterator;
+import java.util.Set;
+
+import javax.sql.DataSource;
+
+import fll.Tournament;
+import fll.db.AwardsScript;
+import fll.util.FLLInternalException;
+import fll.web.ApplicationAttributes;
+import fll.web.AuthenticationContext;
+import fll.web.BaseFLLServlet;
+import fll.web.SessionAttributes;
+import fll.web.UserRole;
+import fll.web.WebUtils;
+import fll.web.developer.importdb.ImportDBDump;
+import fll.web.developer.importdb.ImportDbSessionInfo;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * Commit changes for awards script differences.
+ */
+@WebServlet("/developer/importdb/awardsScript/CommitAwardsScriptChanges")
+public class CommitAwardsScriptChanges extends BaseFLLServlet {
+
+  private static final org.apache.logging.log4j.Logger LOGGER = org.apache.logging.log4j.LogManager.getLogger();
+
+  @Override
+  protected void processRequest(final HttpServletRequest request,
+                                final HttpServletResponse response,
+                                final ServletContext application,
+                                final HttpSession session)
+      throws IOException, ServletException {
+    final AuthenticationContext auth = SessionAttributes.getAuthentication(session);
+    if (!auth.requireRoles(request, response, session, Set.of(UserRole.ADMIN), false)) {
+      return;
+    }
+
+    final ImportDbSessionInfo sessionInfo = SessionAttributes.getNonNullAttribute(session,
+                                                                                  ImportDBDump.IMPORT_DB_SESSION_KEY,
+                                                                                  ImportDbSessionInfo.class);
+
+    final DataSource sourceDataSource = sessionInfo.getImportDataSource();
+    final DataSource destDataSource = ApplicationAttributes.getDataSource(application);
+
+    final String tournamentName = sessionInfo.getTournamentName();
+    if (null == tournamentName) {
+      throw new FLLInternalException("Missing tournament to import");
+    }
+
+    try (Connection sourceConnection = sourceDataSource.getConnection();
+        Connection destConnection = destDataSource.getConnection()) {
+
+      final Tournament sourceTournament = Tournament.findTournamentByName(sourceConnection, tournamentName);
+      final Tournament destTournament = Tournament.findTournamentByName(destConnection, tournamentName);
+
+      for (final ListIterator<AwardsScriptDifference> iter = sessionInfo.getAwardsScriptDifferences()
+                                                                        .listIterator(); iter.hasNext();) {
+        final int index = iter.nextIndex();
+        final AwardsScriptDifference difference = iter.next();
+        final String actionStr = WebUtils.getNonNullRequestParameter(request, String.format("difference_%d", index));
+        final AwardsScriptDifferenceAction action = AwardsScriptDifferenceAction.valueOf(actionStr);
+
+        if (difference instanceof SponsorsDifference) {
+          final SponsorsDifference sd = (SponsorsDifference) difference;
+          applySponsorDifference(sourceConnection, sourceTournament, destConnection, destTournament, sd, action);
+        } else {
+          throw new FLLInternalException(String.format("Unknown data type for awards script difference: %s",
+                                                       difference.getClass().getName()));
+        }
+      }
+    } catch (final SQLException sqle) {
+      LOGGER.error(sqle);
+      throw new RuntimeException("Error talking to the database", sqle);
+    }
+
+    session.setAttribute(SessionAttributes.REDIRECT_URL, "/developer/importdb/awardsScript/CheckAwardsScriptInfo");
+    WebUtils.sendRedirect(response, session);
+  }
+
+  private void applySponsorDifference(final Connection sourceConnection,
+                                      final Tournament sourceTournament,
+                                      final Connection destConnection,
+                                      final Tournament destTournament,
+                                      final SponsorsDifference sd,
+                                      final AwardsScriptDifferenceAction action)
+      throws SQLException {
+    switch (action) {
+    case KEEP_DESTINATION:
+      AwardsScript.updateSponsorsForTournament(sourceConnection, sourceTournament, sd.getDestSponsors());
+      break;
+    case KEEP_SOURCE_AS_TOURNAMENT:
+      AwardsScript.updateSponsorsForTournament(destConnection, destTournament, sd.getSourceSponsors());
+      break;
+    case KEEP_SOURCE_AS_TOURNAMENT_LEVEL:
+      AwardsScript.updateSponsorsForTournamentLevel(destConnection, destTournament.getLevel(), sd.getSourceSponsors());
+      break;
+    case KEEP_SOURCE_AS_SEASON:
+      AwardsScript.updateSponsorsForSeason(destConnection, sd.getSourceSponsors());
+      break;
+    default:
+      throw new FLLInternalException(String.format("Unknown enum value for %s: %s", action.getClass().getName(),
+                                                   action.getName()));
+    }
+
+  }
+
+}

--- a/src/main/java/fll/web/developer/importdb/awardsScript/MacroValueDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/MacroValueDifference.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023 High Tech Kids.  All rights reserved
+ * HighTechKids is on the web at: http://www.hightechkids.org
+ * This code is released under GPL; see LICENSE.txt for details.
+ */
+
+package fll.web.developer.importdb.awardsScript;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import fll.Tournament;
+import fll.db.AwardsScript;
+import fll.db.AwardsScript.Macro;
+import fll.util.FLLInternalException;
+
+/**
+ * Difference in a {@link Macro} value 2 databases.
+ */
+public final class MacroValueDifference extends AwardsScriptDifference {
+
+  /**
+   * @param macro see {@link #getMacro()}
+   * @param sourceValue see {@link #getSourceValue()}
+   * @param destValue see {@link #getDestValue()}
+   */
+  public MacroValueDifference(final Macro macro,
+                              final String sourceValue,
+                              final String destValue) {
+    this.macro = macro;
+    this.sourceValue = sourceValue;
+    this.destValue = destValue;
+  }
+
+  @Override
+  public String getDescription() {
+    final StringBuilder description = new StringBuilder();
+    description.append(String.format("<div>The value of macro %s is different between the source database and the destination database.</div>",
+                                     macro));
+    description.append(String.format("<div>Source: %s</div>", sourceValue));
+    description.append(String.format("<div>Destination:%s </div>", destValue));
+    return description.toString();
+  }
+
+  private final Macro macro;
+
+  /**
+   * @return the macro that has a different value
+   */
+  public Macro getMacro() {
+    return macro;
+  }
+
+  private final String sourceValue;
+
+  /**
+   * @return macro value in the source database
+   */
+  public String getSourceValue() {
+    return sourceValue;
+  }
+
+  private final String destValue;
+
+  /**
+   * @return macro value in the destination database
+   */
+  public String getDestValue() {
+    return destValue;
+  }
+
+  @Override
+  public void resolveDifference(final Connection sourceConnection,
+                                final Tournament sourceTournament,
+                                final Connection destConnection,
+                                final Tournament destTournament,
+                                final AwardsScriptDifferenceAction action)
+      throws SQLException {
+    switch (action) {
+    case KEEP_DESTINATION:
+      AwardsScript.updateMacroValueForTournament(sourceConnection, sourceTournament, getMacro(), getDestValue());
+      break;
+    case KEEP_SOURCE_AS_TOURNAMENT:
+      AwardsScript.updateMacroValueForTournament(destConnection, destTournament, getMacro(), getSourceValue());
+      break;
+    case KEEP_SOURCE_AS_TOURNAMENT_LEVEL:
+      AwardsScript.updateMacroValueForTournamentLevel(destConnection, destTournament.getLevel(), getMacro(),
+                                                      getSourceValue());
+      break;
+    case KEEP_SOURCE_AS_SEASON:
+      AwardsScript.updateMacroValueForSeason(destConnection, getMacro(), getSourceValue());
+      break;
+    default:
+      throw new FLLInternalException(String.format("Unknown enum value for %s: %s", action.getClass().getName(),
+                                                   action.getName()));
+    }
+  }
+}

--- a/src/main/java/fll/web/developer/importdb/awardsScript/MacroValueDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/MacroValueDifference.java
@@ -31,14 +31,8 @@ public final class MacroValueDifference extends StringDifference {
     this.macro = macro;
   }
 
-  @Override
-  public String getDescription() {
-    final StringBuilder description = new StringBuilder();
-    description.append(String.format("<div>The value of macro %s is different between the source database and the destination database.</div>",
-                                     getMacro()));
-    description.append(String.format("<div>Source: %s</div>", getSourceValue()));
-    description.append(String.format("<div>Destination:%s </div>", getDestValue()));
-    return description.toString();
+  protected String getTextDescription() {
+    return String.format("value of macro %s", getMacro());
   }
 
   private final Macro macro;

--- a/src/main/java/fll/web/developer/importdb/awardsScript/MacroValueDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/MacroValueDifference.java
@@ -17,7 +17,7 @@ import fll.util.FLLInternalException;
 /**
  * Difference in a {@link Macro} value 2 databases.
  */
-public final class MacroValueDifference extends AwardsScriptDifference {
+public final class MacroValueDifference extends StringDifference {
 
   /**
    * @param macro see {@link #getMacro()}
@@ -27,18 +27,17 @@ public final class MacroValueDifference extends AwardsScriptDifference {
   public MacroValueDifference(final Macro macro,
                               final String sourceValue,
                               final String destValue) {
+    super(sourceValue, destValue);
     this.macro = macro;
-    this.sourceValue = sourceValue;
-    this.destValue = destValue;
   }
 
   @Override
   public String getDescription() {
     final StringBuilder description = new StringBuilder();
     description.append(String.format("<div>The value of macro %s is different between the source database and the destination database.</div>",
-                                     macro));
-    description.append(String.format("<div>Source: %s</div>", sourceValue));
-    description.append(String.format("<div>Destination:%s </div>", destValue));
+                                     getMacro()));
+    description.append(String.format("<div>Source: %s</div>", getSourceValue()));
+    description.append(String.format("<div>Destination:%s </div>", getDestValue()));
     return description.toString();
   }
 
@@ -49,24 +48,6 @@ public final class MacroValueDifference extends AwardsScriptDifference {
    */
   public Macro getMacro() {
     return macro;
-  }
-
-  private final String sourceValue;
-
-  /**
-   * @return macro value in the source database
-   */
-  public String getSourceValue() {
-    return sourceValue;
-  }
-
-  private final String destValue;
-
-  /**
-   * @return macro value in the destination database
-   */
-  public String getDestValue() {
-    return destValue;
   }
 
   @Override

--- a/src/main/java/fll/web/developer/importdb/awardsScript/NonNumericCategoryPresenterDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/NonNumericCategoryPresenterDifference.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 High Tech Kids.  All rights reserved
+ * HighTechKids is on the web at: http://www.hightechkids.org
+ * This code is released under GPL; see LICENSE.txt for details.
+ */
+
+package fll.web.developer.importdb.awardsScript;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import fll.Tournament;
+import fll.db.AwardsScript;
+import fll.util.FLLInternalException;
+import fll.xml.NonNumericCategory;
+
+/**
+ * Difference in the presenter for a non-numeric category between 2 databases.
+ */
+public class NonNumericCategoryPresenterDifference extends CategoryPresenterDifference {
+
+  /**
+   * @param category see {@link #getCategory()}
+   * @param sourceValue see {@link #getSourceValue()}
+   * @param destValue see {@link #getDestValue()}
+   */
+  public NonNumericCategoryPresenterDifference(final NonNumericCategory category,
+                                               final String sourceValue,
+                                               final String destValue) {
+    super(category, sourceValue, destValue);
+    this.category = category;
+  }
+
+  private final NonNumericCategory category;
+
+  @Override
+  public NonNumericCategory getCategory() {
+    return category;
+  }
+
+  @Override
+  public void resolveDifference(final Connection sourceConnection,
+                                final Tournament sourceTournament,
+                                final Connection destConnection,
+                                final Tournament destTournament,
+                                final AwardsScriptDifferenceAction action)
+      throws SQLException {
+    switch (action) {
+    case KEEP_DESTINATION:
+      AwardsScript.updatePresenterForTournament(sourceConnection, sourceTournament, getCategory(), getDestValue());
+      break;
+    case KEEP_SOURCE_AS_TOURNAMENT:
+      AwardsScript.updatePresenterForTournament(destConnection, destTournament, getCategory(), getSourceValue());
+      break;
+    case KEEP_SOURCE_AS_TOURNAMENT_LEVEL:
+      AwardsScript.updatePresenterForTournamentLevel(destConnection, destTournament.getLevel(), getCategory(),
+                                                     getSourceValue());
+      break;
+    case KEEP_SOURCE_AS_SEASON:
+      AwardsScript.updatePresenterForSeason(destConnection, getCategory(), getSourceValue());
+      break;
+    default:
+      throw new FLLInternalException(String.format("Unknown enum value for %s: %s", action.getClass().getName(),
+                                                   action.getName()));
+    }
+  }
+
+}

--- a/src/main/java/fll/web/developer/importdb/awardsScript/NonNumericCategoryTextDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/NonNumericCategoryTextDifference.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 High Tech Kids.  All rights reserved
+ * HighTechKids is on the web at: http://www.hightechkids.org
+ * This code is released under GPL; see LICENSE.txt for details.
+ */
+
+package fll.web.developer.importdb.awardsScript;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import fll.Tournament;
+import fll.db.AwardsScript;
+import fll.util.FLLInternalException;
+import fll.xml.NonNumericCategory;
+
+/**
+ * Difference in the text for a non-numeric category between 2 databases.
+ */
+public class NonNumericCategoryTextDifference extends CategoryTextDifference {
+
+  /**
+   * @param category see {@link #getCategory()}
+   * @param sourceValue see {@link #getSourceValue()}
+   * @param destValue see {@link #getDestValue()}
+   */
+  public NonNumericCategoryTextDifference(final NonNumericCategory category,
+                                          final String sourceValue,
+                                          final String destValue) {
+    super(category, sourceValue, destValue);
+    this.category = category;
+  }
+
+  private final NonNumericCategory category;
+
+  @Override
+  public NonNumericCategory getCategory() {
+    return category;
+  }
+
+  @Override
+  public void resolveDifference(final Connection sourceConnection,
+                                final Tournament sourceTournament,
+                                final Connection destConnection,
+                                final Tournament destTournament,
+                                final AwardsScriptDifferenceAction action)
+      throws SQLException {
+    switch (action) {
+    case KEEP_DESTINATION:
+      AwardsScript.updateCategoryTextForTournament(sourceConnection, sourceTournament, getCategory(), getDestValue());
+      break;
+    case KEEP_SOURCE_AS_TOURNAMENT:
+      AwardsScript.updateCategoryTextForTournament(destConnection, destTournament, getCategory(), getSourceValue());
+      break;
+    case KEEP_SOURCE_AS_TOURNAMENT_LEVEL:
+      AwardsScript.updateCategoryTextForTournamentLevel(destConnection, destTournament.getLevel(), getCategory(),
+                                                        getSourceValue());
+      break;
+    case KEEP_SOURCE_AS_SEASON:
+      AwardsScript.updateCategoryTextForSeason(destConnection, getCategory(), getSourceValue());
+      break;
+    default:
+      throw new FLLInternalException(String.format("Unknown enum value for %s: %s", action.getClass().getName(),
+                                                   action.getName()));
+    }
+  }
+
+}

--- a/src/main/java/fll/web/developer/importdb/awardsScript/NumPerformanceAwardsDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/NumPerformanceAwardsDifference.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023 High Tech Kids.  All rights reserved
+ * HighTechKids is on the web at: http://www.hightechkids.org
+ * This code is released under GPL; see LICENSE.txt for details.
+ */
+
+package fll.web.developer.importdb.awardsScript;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import fll.Tournament;
+import fll.db.AwardsScript;
+import fll.util.FLLInternalException;
+
+/**
+ * Difference in the number of performance awards between 2 databases.
+ */
+public final class NumPerformanceAwardsDifference extends AwardsScriptDifference {
+
+  /**
+   * @param sourceValue see {@link #getSourceValue()}
+   * @param destValue see {@link #getDestValue()}
+   */
+  public NumPerformanceAwardsDifference(final int sourceValue,
+                                        final int destValue) {
+    this.sourceValue = sourceValue;
+    this.destValue = destValue;
+  }
+
+  @Override
+  public String getDescription() {
+    final StringBuilder description = new StringBuilder();
+    description.append("<div>The number of performance awards is different between the source database and the destination database.</div>");
+    description.append(String.format("<div>Source: %s</div>", sourceValue));
+    description.append(String.format("<div>Destination:%s </div>", destValue));
+    return description.toString();
+  }
+
+  private final int sourceValue;
+
+  /**
+   * @return num performance awards in the source database
+   */
+  public int getSourceValue() {
+    return sourceValue;
+  }
+
+  private final int destValue;
+
+  /**
+   * @return num performance awards in the destination database
+   */
+  public int getDestValue() {
+    return destValue;
+  }
+
+  @Override
+  public void resolveDifference(final Connection sourceConnection,
+                                final Tournament sourceTournament,
+                                final Connection destConnection,
+                                final Tournament destTournament,
+                                final AwardsScriptDifferenceAction action)
+      throws SQLException {
+    switch (action) {
+    case KEEP_DESTINATION:
+      AwardsScript.updateNumPerformanceAwardsForTournament(sourceConnection, sourceTournament, getDestValue());
+      break;
+    case KEEP_SOURCE_AS_TOURNAMENT:
+      AwardsScript.updateNumPerformanceAwardsForTournament(destConnection, destTournament, getSourceValue());
+      break;
+    case KEEP_SOURCE_AS_TOURNAMENT_LEVEL:
+      AwardsScript.updateNumPerformanceAwardsForTournamentLevel(destConnection, destTournament.getLevel(),
+                                                                getSourceValue());
+      break;
+    case KEEP_SOURCE_AS_SEASON:
+      AwardsScript.updateNumPerformanceAwardsForSeason(destConnection, getSourceValue());
+      break;
+    default:
+      throw new FLLInternalException(String.format("Unknown enum value for %s: %s", action.getClass().getName(),
+                                                   action.getName()));
+    }
+  }
+}

--- a/src/main/java/fll/web/developer/importdb/awardsScript/ResolveAwardsScriptDifferences.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/ResolveAwardsScriptDifferences.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 High Tech Kids.  All rights reserved
+ * HighTechKids is on the web at: http://www.hightechkids.org
+ * This code is released under GPL; see LICENSE.txt for details.
+ */
+
+package fll.web.developer.importdb.awardsScript;
+
+import jakarta.servlet.jsp.PageContext;
+
+/**
+ * Helper for resolveAwardsScriptDifferences.jsp.
+ */
+public final class ResolveAwardsScriptDifferences {
+
+  private ResolveAwardsScriptDifferences() {
+  }
+
+  /**
+   * Setup context variables for the page.
+   * 
+   * @param page page context
+   */
+  public static void populateContext(final PageContext page) {
+    page.setAttribute("awardsScriptDifferenceActionValues", AwardsScriptDifferenceAction.values());
+  }
+
+}

--- a/src/main/java/fll/web/developer/importdb/awardsScript/SectionTextDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/SectionTextDifference.java
@@ -31,14 +31,8 @@ public final class SectionTextDifference extends StringDifference {
     this.section = section;
   }
 
-  @Override
-  public String getDescription() {
-    final StringBuilder description = new StringBuilder();
-    description.append(String.format("<div>The text for section %s is different between the source database and the destination database.</div>",
-                                     getSection()));
-    description.append(String.format("<div>Source: %s</div>", getSourceValue()));
-    description.append(String.format("<div>Destination:%s </div>", getDestValue()));
-    return description.toString();
+  protected String getTextDescription() {
+    return String.format("text for section %s", getSection());
   }
 
   private final Section section;

--- a/src/main/java/fll/web/developer/importdb/awardsScript/SectionTextDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/SectionTextDifference.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023 High Tech Kids.  All rights reserved
+ * HighTechKids is on the web at: http://www.hightechkids.org
+ * This code is released under GPL; see LICENSE.txt for details.
+ */
+
+package fll.web.developer.importdb.awardsScript;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import fll.Tournament;
+import fll.db.AwardsScript;
+import fll.db.AwardsScript.Section;
+import fll.util.FLLInternalException;
+
+/**
+ * Difference in the text for a {@link Section} between 2 databases.
+ */
+public final class SectionTextDifference extends AwardsScriptDifference {
+
+  /**
+   * @param section see {@link #getSection()}
+   * @param sourceValue see {@link #getSourceValue()}
+   * @param destValue see {@link #getDestValue()}
+   */
+  public SectionTextDifference(final Section section,
+                               final String sourceValue,
+                               final String destValue) {
+    this.section = section;
+    this.sourceValue = sourceValue;
+    this.destValue = destValue;
+  }
+
+  @Override
+  public String getDescription() {
+    final StringBuilder description = new StringBuilder();
+    description.append(String.format("<div>The text for section %s is different between the source database and the destination database.</div>",
+                                     section));
+    description.append(String.format("<div>Source: %s</div>", sourceValue));
+    description.append(String.format("<div>Destination:%s </div>", destValue));
+    return description.toString();
+  }
+
+  private final Section section;
+
+  /**
+   * @return the section that has a different value
+   */
+  public Section getSection() {
+    return section;
+  }
+
+  private final String sourceValue;
+
+  /**
+   * @return macro value in the source database
+   */
+  public String getSourceValue() {
+    return sourceValue;
+  }
+
+  private final String destValue;
+
+  /**
+   * @return macro value in the destination database
+   */
+  public String getDestValue() {
+    return destValue;
+  }
+
+  @Override
+  public void resolveDifference(final Connection sourceConnection,
+                                final Tournament sourceTournament,
+                                final Connection destConnection,
+                                final Tournament destTournament,
+                                final AwardsScriptDifferenceAction action)
+      throws SQLException {
+    switch (action) {
+    case KEEP_DESTINATION:
+      AwardsScript.updateSectionTextForTournament(sourceConnection, sourceTournament, getSection(), getDestValue());
+      break;
+    case KEEP_SOURCE_AS_TOURNAMENT:
+      AwardsScript.updateSectionTextForTournament(destConnection, destTournament, getSection(), getSourceValue());
+      break;
+    case KEEP_SOURCE_AS_TOURNAMENT_LEVEL:
+      AwardsScript.updateSectionTextForTournamentLevel(destConnection, destTournament.getLevel(), getSection(),
+                                                       getSourceValue());
+      break;
+    case KEEP_SOURCE_AS_SEASON:
+      AwardsScript.updateSectionTextForSeason(destConnection, getSection(), getSourceValue());
+      break;
+    default:
+      throw new FLLInternalException(String.format("Unknown enum value for %s: %s", action.getClass().getName(),
+                                                   action.getName()));
+    }
+  }
+}

--- a/src/main/java/fll/web/developer/importdb/awardsScript/SectionTextDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/SectionTextDifference.java
@@ -17,7 +17,7 @@ import fll.util.FLLInternalException;
 /**
  * Difference in the text for a {@link Section} between 2 databases.
  */
-public final class SectionTextDifference extends AwardsScriptDifference {
+public final class SectionTextDifference extends StringDifference {
 
   /**
    * @param section see {@link #getSection()}
@@ -27,18 +27,17 @@ public final class SectionTextDifference extends AwardsScriptDifference {
   public SectionTextDifference(final Section section,
                                final String sourceValue,
                                final String destValue) {
+    super(sourceValue, destValue);
     this.section = section;
-    this.sourceValue = sourceValue;
-    this.destValue = destValue;
   }
 
   @Override
   public String getDescription() {
     final StringBuilder description = new StringBuilder();
     description.append(String.format("<div>The text for section %s is different between the source database and the destination database.</div>",
-                                     section));
-    description.append(String.format("<div>Source: %s</div>", sourceValue));
-    description.append(String.format("<div>Destination:%s </div>", destValue));
+                                     getSection()));
+    description.append(String.format("<div>Source: %s</div>", getSourceValue()));
+    description.append(String.format("<div>Destination:%s </div>", getDestValue()));
     return description.toString();
   }
 
@@ -49,24 +48,6 @@ public final class SectionTextDifference extends AwardsScriptDifference {
    */
   public Section getSection() {
     return section;
-  }
-
-  private final String sourceValue;
-
-  /**
-   * @return macro value in the source database
-   */
-  public String getSourceValue() {
-    return sourceValue;
-  }
-
-  private final String destValue;
-
-  /**
-   * @return macro value in the destination database
-   */
-  public String getDestValue() {
-    return destValue;
   }
 
   @Override

--- a/src/main/java/fll/web/developer/importdb/awardsScript/SponsorsDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/SponsorsDifference.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023 High Tech Kids.  All rights reserved
+ * HighTechKids is on the web at: http://www.hightechkids.org
+ * This code is released under GPL; see LICENSE.txt for details.
+ */
+
+package fll.web.developer.importdb.awardsScript;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Difference in the sponsors list between 2 databases.
+ */
+public final class SponsorsDifference extends AwardsScriptDifference {
+
+  /**
+   * @param sourceValue see {@link #getSourceSponsors()}
+   * @param destValue see {@link #getDestSponsors()}
+   */
+  public SponsorsDifference(final List<String> sourceValue,
+                            final List<String> destValue) {
+    this.sourceValue = Collections.unmodifiableList(new ArrayList<>(sourceValue));
+    this.destValue = Collections.unmodifiableList(new ArrayList<>(destValue));
+  }
+
+  @Override
+  public String getDescription() {
+    final StringBuilder description = new StringBuilder();
+    description.append("<div>The list of sponsors is different between the source database and the destination database.</div>");
+    description.append("<div>Source:<ul>");
+    for (final String svalue : sourceValue) {
+      description.append("<li>");
+      description.append(svalue);
+      description.append("</li>");
+    }
+    description.append("</ul></div>");
+    description.append("<div>Destination:<ul>");
+    for (final String dvalue : destValue) {
+      description.append("<li>");
+      description.append(dvalue);
+      description.append("</li>");
+    }
+    description.append("</ul></div>");
+    return description.toString();
+  }
+
+  private final List<String> sourceValue;
+
+  /**
+   * @return sponsors in the source database (unmodifiable)
+   */
+  public List<String> getSourceSponsors() {
+    return sourceValue;
+  }
+
+  private final List<String> destValue;
+
+  /**
+   * @return sponsors in the destination database (unmodifiable)
+   */
+  public List<String> getDestSponsors() {
+    return destValue;
+  }
+}

--- a/src/main/java/fll/web/developer/importdb/awardsScript/SponsorsDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/SponsorsDifference.java
@@ -23,7 +23,7 @@ public final class SponsorsDifference extends AwardsScriptDifference {
 
   /**
    * @param sourceValue see {@link #getSourceValue()}
-   * @param destValue see {@link #getDestValues()}
+   * @param destValue see {@link #getDestValue()}
    */
   public SponsorsDifference(final List<String> sourceValue,
                             final List<String> destValue) {

--- a/src/main/java/fll/web/developer/importdb/awardsScript/StringDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/StringDifference.java
@@ -26,8 +26,21 @@ import fll.Tournament;
     this.destValue = destValue;
   }
 
+  /**
+   * @return descriptive text for the description. See source for
+   *         {@link #getDescription()} for details.
+   */
+  protected abstract String getTextDescription();
+
   @Override
-  public abstract String getDescription();
+  public final String getDescription() {
+    final StringBuilder description = new StringBuilder();
+    description.append(String.format("<div>The % is different between the source database and the destination database.</div>",
+                                     getTextDescription()));
+    description.append(String.format("<div>Source: %s</div>", getSourceValue()));
+    description.append(String.format("<div>Destination:%s </div>", getDestValue()));
+    return description.toString();
+  }
 
   private final String sourceValue;
 

--- a/src/main/java/fll/web/developer/importdb/awardsScript/StringDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/StringDifference.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 High Tech Kids.  All rights reserved
+ * HighTechKids is on the web at: http://www.hightechkids.org
+ * This code is released under GPL; see LICENSE.txt for details.
+ */
+
+package fll.web.developer.importdb.awardsScript;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import fll.Tournament;
+
+/**
+ * Base class for differences where the value is a string.
+ */
+/* package */ abstract class StringDifference extends AwardsScriptDifference {
+
+  /**
+   * @param sourceValue see {@link #getSourceValue()}
+   * @param destValue see {@link #getDestValue()}
+   */
+  /* package */ StringDifference(final String sourceValue,
+                                 final String destValue) {
+    this.sourceValue = sourceValue;
+    this.destValue = destValue;
+  }
+
+  @Override
+  public abstract String getDescription();
+
+  private final String sourceValue;
+
+  /**
+   * @return value in the source database
+   */
+  public final String getSourceValue() {
+    return sourceValue;
+  }
+
+  private final String destValue;
+
+  /**
+   * @return value in the destination database
+   */
+  public final String getDestValue() {
+    return destValue;
+  }
+
+  @Override
+  public abstract void resolveDifference(Connection sourceConnection,
+                                         Tournament sourceTournament,
+                                         Connection destConnection,
+                                         Tournament destTournament,
+                                         AwardsScriptDifferenceAction action)
+      throws SQLException;
+
+}

--- a/src/main/java/fll/web/developer/importdb/awardsScript/SubjectiveCategoryPresenterDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/SubjectiveCategoryPresenterDifference.java
@@ -17,7 +17,7 @@ import fll.xml.SubjectiveScoreCategory;
 /**
  * Difference in the presenter for a subjective category between 2 databases.
  */
-public class SubjectiveCategoryPresenterDifference extends CategoryTextDifference {
+public class SubjectiveCategoryPresenterDifference extends CategoryPresenterDifference {
 
   /**
    * @param category see {@link #getCategory()}

--- a/src/main/java/fll/web/developer/importdb/awardsScript/SubjectiveCategoryPresenterDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/SubjectiveCategoryPresenterDifference.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 High Tech Kids.  All rights reserved
+ * HighTechKids is on the web at: http://www.hightechkids.org
+ * This code is released under GPL; see LICENSE.txt for details.
+ */
+
+package fll.web.developer.importdb.awardsScript;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import fll.Tournament;
+import fll.db.AwardsScript;
+import fll.util.FLLInternalException;
+import fll.xml.SubjectiveScoreCategory;
+
+/**
+ * Difference in the presenter for a subjective category between 2 databases.
+ */
+public class SubjectiveCategoryPresenterDifference extends CategoryTextDifference {
+
+  /**
+   * @param category see {@link #getCategory()}
+   * @param sourceValue see {@link #getSourceValue()}
+   * @param destValue see {@link #getDestValue()}
+   */
+  public SubjectiveCategoryPresenterDifference(final SubjectiveScoreCategory category,
+                                               final String sourceValue,
+                                               final String destValue) {
+    super(category, sourceValue, destValue);
+    this.category = category;
+  }
+
+  private final SubjectiveScoreCategory category;
+
+  @Override
+  public SubjectiveScoreCategory getCategory() {
+    return category;
+  }
+
+  @Override
+  public void resolveDifference(final Connection sourceConnection,
+                                final Tournament sourceTournament,
+                                final Connection destConnection,
+                                final Tournament destTournament,
+                                final AwardsScriptDifferenceAction action)
+      throws SQLException {
+    switch (action) {
+    case KEEP_DESTINATION:
+      AwardsScript.updatePresenterForTournament(sourceConnection, sourceTournament, getCategory(), getDestValue());
+      break;
+    case KEEP_SOURCE_AS_TOURNAMENT:
+      AwardsScript.updatePresenterForTournament(destConnection, destTournament, getCategory(), getSourceValue());
+      break;
+    case KEEP_SOURCE_AS_TOURNAMENT_LEVEL:
+      AwardsScript.updatePresenterForTournamentLevel(destConnection, destTournament.getLevel(), getCategory(),
+                                                     getSourceValue());
+      break;
+    case KEEP_SOURCE_AS_SEASON:
+      AwardsScript.updatePresenterForSeason(destConnection, getCategory(), getSourceValue());
+      break;
+    default:
+      throw new FLLInternalException(String.format("Unknown enum value for %s: %s", action.getClass().getName(),
+                                                   action.getName()));
+    }
+  }
+
+}

--- a/src/main/java/fll/web/developer/importdb/awardsScript/SubjectiveCategoryTextDifference.java
+++ b/src/main/java/fll/web/developer/importdb/awardsScript/SubjectiveCategoryTextDifference.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 High Tech Kids.  All rights reserved
+ * HighTechKids is on the web at: http://www.hightechkids.org
+ * This code is released under GPL; see LICENSE.txt for details.
+ */
+
+package fll.web.developer.importdb.awardsScript;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import fll.Tournament;
+import fll.db.AwardsScript;
+import fll.util.FLLInternalException;
+import fll.xml.SubjectiveScoreCategory;
+
+/**
+ * Difference in the text for a subjective category between 2 databases.
+ */
+public class SubjectiveCategoryTextDifference extends CategoryTextDifference {
+
+  /**
+   * @param category see {@link #getCategory()}
+   * @param sourceValue see {@link #getSourceValue()}
+   * @param destValue see {@link #getDestValue()}
+   */
+  public SubjectiveCategoryTextDifference(final SubjectiveScoreCategory category,
+                                          final String sourceValue,
+                                          final String destValue) {
+    super(category, sourceValue, destValue);
+    this.category = category;
+  }
+
+  private final SubjectiveScoreCategory category;
+
+  @Override
+  public SubjectiveScoreCategory getCategory() {
+    return category;
+  }
+
+  @Override
+  public void resolveDifference(final Connection sourceConnection,
+                                final Tournament sourceTournament,
+                                final Connection destConnection,
+                                final Tournament destTournament,
+                                final AwardsScriptDifferenceAction action)
+      throws SQLException {
+    switch (action) {
+    case KEEP_DESTINATION:
+      AwardsScript.updateCategoryTextForTournament(sourceConnection, sourceTournament, getCategory(), getDestValue());
+      break;
+    case KEEP_SOURCE_AS_TOURNAMENT:
+      AwardsScript.updateCategoryTextForTournament(destConnection, destTournament, getCategory(), getSourceValue());
+      break;
+    case KEEP_SOURCE_AS_TOURNAMENT_LEVEL:
+      AwardsScript.updateCategoryTextForTournamentLevel(destConnection, destTournament.getLevel(), getCategory(),
+                                                        getSourceValue());
+      break;
+    case KEEP_SOURCE_AS_SEASON:
+      AwardsScript.updateCategoryTextForSeason(destConnection, getCategory(), getSourceValue());
+      break;
+    default:
+      throw new FLLInternalException(String.format("Unknown enum value for %s: %s", action.getClass().getName(),
+                                                   action.getName()));
+    }
+  }
+
+}

--- a/src/main/java/fll/web/report/awards/ChampionshipCategory.java
+++ b/src/main/java/fll/web/report/awards/ChampionshipCategory.java
@@ -38,4 +38,24 @@ public final class ChampionshipCategory implements AwardCategory {
     return true;
   }
 
+  @Override
+  public int hashCode() {
+    return getTitle().hashCode();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (null == o) {
+      return false;
+    } else if (this == o) {
+      return true;
+    } else if (!o.getClass().equals(this.getClass())) {
+      return false;
+    } else {
+      final ChampionshipCategory other = (ChampionshipCategory) o;
+      return getTitle().equals(other.getTitle())
+          && getPerAwardGroup() == other.getPerAwardGroup();
+    }
+  }
+
 }

--- a/src/main/java/fll/web/report/awards/ChampionshipCategory.java
+++ b/src/main/java/fll/web/report/awards/ChampionshipCategory.java
@@ -6,6 +6,8 @@
 
 package fll.web.report.awards;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * Store information about the championship.
  */
@@ -44,7 +46,7 @@ public final class ChampionshipCategory implements AwardCategory {
   }
 
   @Override
-  public boolean equals(final Object o) {
+  public boolean equals(final @Nullable Object o) {
     if (null == o) {
       return false;
     } else if (this == o) {

--- a/src/main/java/fll/web/report/awards/HeadToHeadCategory.java
+++ b/src/main/java/fll/web/report/awards/HeadToHeadCategory.java
@@ -34,4 +34,24 @@ public final class HeadToHeadCategory implements AwardCategory {
     return true;
   }
 
+  @Override
+  public int hashCode() {
+    return getTitle().hashCode();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (null == o) {
+      return false;
+    } else if (this == o) {
+      return true;
+    } else if (!o.getClass().equals(this.getClass())) {
+      return false;
+    } else {
+      final HeadToHeadCategory other = (HeadToHeadCategory) o;
+      return getTitle().equals(other.getTitle())
+          && getPerAwardGroup() == other.getPerAwardGroup();
+    }
+  }
+
 }

--- a/src/main/java/fll/web/report/awards/HeadToHeadCategory.java
+++ b/src/main/java/fll/web/report/awards/HeadToHeadCategory.java
@@ -6,6 +6,8 @@
 
 package fll.web.report.awards;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * Store information about the head to head category.
  */
@@ -40,7 +42,7 @@ public final class HeadToHeadCategory implements AwardCategory {
   }
 
   @Override
-  public boolean equals(final Object o) {
+  public boolean equals(final @Nullable Object o) {
     if (null == o) {
       return false;
     } else if (this == o) {

--- a/src/main/java/fll/xml/NonNumericCategory.java
+++ b/src/main/java/fll/xml/NonNumericCategory.java
@@ -162,4 +162,24 @@ public class NonNumericCategory implements AwardCategory, Serializable {
     return ele;
   }
 
+  @Override
+  public int hashCode() {
+    return getTitle().hashCode();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (null == o) {
+      return false;
+    } else if (this == o) {
+      return true;
+    } else if (!o.getClass().equals(this.getClass())) {
+      return false;
+    } else {
+      final NonNumericCategory other = (NonNumericCategory) o;
+      return getTitle().equals(other.getTitle())
+          && getPerAwardGroup() == other.getPerAwardGroup();
+    }
+  }
+
 }

--- a/src/main/java/fll/xml/NonNumericCategory.java
+++ b/src/main/java/fll/xml/NonNumericCategory.java
@@ -168,7 +168,7 @@ public class NonNumericCategory implements AwardCategory, Serializable {
   }
 
   @Override
-  public boolean equals(final Object o) {
+  public boolean equals(final @Nullable Object o) {
     if (null == o) {
       return false;
     } else if (this == o) {

--- a/src/main/java/fll/xml/PerformanceScoreCategory.java
+++ b/src/main/java/fll/xml/PerformanceScoreCategory.java
@@ -6,8 +6,6 @@
 
 package fll.xml;
 
-import static org.checkerframework.checker.nullness.util.NullnessUtil.castNonNull;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -16,6 +14,8 @@ import java.util.List;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+
+import static org.checkerframework.checker.nullness.util.NullnessUtil.castNonNull;
 
 import fll.Utilities;
 import fll.web.playoff.TeamScore;
@@ -263,6 +263,26 @@ public class PerformanceScoreCategory extends ScoreCategory implements AwardCate
   @Override
   public boolean getPerAwardGroup() {
     return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return getTitle().hashCode();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (null == o) {
+      return false;
+    } else if (this == o) {
+      return true;
+    } else if (!o.getClass().equals(this.getClass())) {
+      return false;
+    } else {
+      final PerformanceScoreCategory other = (PerformanceScoreCategory) o;
+      return getTitle().equals(other.getTitle())
+          && getPerAwardGroup() == other.getPerAwardGroup();
+    }
   }
 
 }

--- a/src/main/java/fll/xml/PerformanceScoreCategory.java
+++ b/src/main/java/fll/xml/PerformanceScoreCategory.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -271,7 +272,7 @@ public class PerformanceScoreCategory extends ScoreCategory implements AwardCate
   }
 
   @Override
-  public boolean equals(final Object o) {
+  public boolean equals(final @Nullable Object o) {
     if (null == o) {
       return false;
     } else if (this == o) {

--- a/src/main/java/fll/xml/SubjectiveScoreCategory.java
+++ b/src/main/java/fll/xml/SubjectiveScoreCategory.java
@@ -282,7 +282,7 @@ public class SubjectiveScoreCategory extends ScoreCategory implements AwardCateg
   }
 
   @Override
-  public boolean equals(final Object o) {
+  public boolean equals(final @Nullable Object o) {
     if (null == o) {
       return false;
     } else if (this == o) {

--- a/src/main/java/fll/xml/SubjectiveScoreCategory.java
+++ b/src/main/java/fll/xml/SubjectiveScoreCategory.java
@@ -276,4 +276,24 @@ public class SubjectiveScoreCategory extends ScoreCategory implements AwardCateg
         + this.getName();
   }
 
+  @Override
+  public int hashCode() {
+    return getTitle().hashCode();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (null == o) {
+      return false;
+    } else if (this == o) {
+      return true;
+    } else if (!o.getClass().equals(this.getClass())) {
+      return false;
+    } else {
+      final SubjectiveScoreCategory other = (SubjectiveScoreCategory) o;
+      return getTitle().equals(other.getTitle())
+          && getPerAwardGroup() == other.getPerAwardGroup();
+    }
+  }
+
 }

--- a/src/main/web/developer/importdb/awardsScript/resolveAwardsScriptDifferences.jsp
+++ b/src/main/web/developer/importdb/awardsScript/resolveAwardsScriptDifferences.jsp
@@ -1,0 +1,57 @@
+<%@page
+    import="fll.web.developer.importdb.awardsScript.ResolveAwardsScriptDifferences"%>
+<%@ include file="/WEB-INF/jspf/init.jspf"%>
+
+<fll-sw:required-roles roles="ADMIN" allowSetup="false" />
+
+<%
+ResolveAwardsScriptDifferences.populateContext(pageContext);
+%>
+
+<html>
+<head>
+<link rel="stylesheet" type="text/css"
+    href="<c:url value='/style/fll-sw.css'/>" />
+<title>Resolve Awards Script information differences</title>
+</head>
+
+<body>
+
+    <div class='status-message'>${message}</div>
+    <%-- clear out the message, so that we don't see it again --%>
+    <c:remove var="message" />
+
+    <form name="resolveAwardsScriptDifferences"
+        action="CommitAwardsScriptChanges">
+        <p>There are differences in the awards script between the
+            source (imported) database and the destination database. You
+            need to choose to accept the value from the source database
+            or the value from the destination database.</p>
+
+        <c:forEach
+            items="${importDbSessionInfo.awardsScriptDifferences}"
+            var="difference" varStatus="loopStatus">
+            <p>${difference.description}</p>
+            <c:forEach items="${awardsScriptDifferenceActionValues}"
+                var="differenceAction">
+                <input type='radio' name='${loopStatus.index}'
+                    value='${differenceAction.name}' required />
+                ${differenceAction.description}
+                <br />
+            </c:forEach>
+            <hr />
+        </c:forEach>
+
+
+        <input name='submit_data' type='submit' value="Apply Changes" />
+    </form>
+
+    <p>
+        Return to the <a
+            href="<c:url value='/developer/importdb/selectTournament.jsp'/>">tournament
+            selection page</a>.
+    </p>
+
+
+</body>
+</html>

--- a/src/main/web/developer/importdb/awardsScript/resolveAwardsScriptDifferences.jsp
+++ b/src/main/web/developer/importdb/awardsScript/resolveAwardsScriptDifferences.jsp
@@ -34,7 +34,7 @@ ResolveAwardsScriptDifferences.populateContext(pageContext);
             <p>${difference.description}</p>
             <c:forEach items="${awardsScriptDifferenceActionValues}"
                 var="differenceAction">
-                <input type='radio' name='${loopStatus.index}'
+                <input type='radio' name='difference_${loopStatus.index}'
                     value='${differenceAction.name}' required />
                 ${differenceAction.description}
                 <br />


### PR DESCRIPTION
When merging a database in we need to allow one to import tournament level information as well as tournament information. This is due to the changes around the awards script (#211) and categories awarded (#957).