### PR TITLE
New git version plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -620,6 +620,10 @@ tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {
 gitProperties {
     gitPropertiesResourceDir = file("${buildDir}/resources/main/fll/resources")
 }
+tasks.register("writeVersion", WriteProperties) {
+    outputFile = file("${buildDir}/resources/main/fll/resources/git.properties")
+    property "git.build.version", project.version
+}
 
 tasks.register("writeLaunchJar", Jar) {
     destinationDirectory = project.buildDir

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ plugins {
     id "com.github.spotbugs" version "5.0.13"
     id "de.aaschmid.cpd" version "3.3"
     id "edu.sc.seis.launch4j" version "2.5.4"
-    id "com.gorylenko.gradle-git-properties" version "2.4.1"
     id "com.github.ben-manes.versions" version "0.46.0" // adds dependencyUpdates task
     id "de.undercouch.download" version "5.3.1" // file download
     id "checkstyle"
@@ -617,13 +616,11 @@ tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {
 }
 
 
-gitProperties {
-    gitPropertiesResourceDir = file("${buildDir}/resources/main/fll/resources")
-}
 tasks.register("writeVersion", WriteProperties) {
     outputFile = file("${buildDir}/resources/main/fll/resources/git.properties")
     property "git.build.version", project.version
 }
+tasks.named("classes") { finalizedBy("writeVersion") }
 
 tasks.register("writeLaunchJar", Jar) {
     destinationDirectory = project.buildDir


### PR DESCRIPTION
Replace the git-properties plugin. This plugin relies on jgit, which doesn't support git worktrees. I'd like to start using worktrees for some development and this plugin is preventing that from happening. 
After looking at what information the code displays about git and what is in the build version I have determined that only the project build version from gradle is needed, so I've written a simple task that stores that in the properties file read by `Version.java` using the same key for the build version.